### PR TITLE
Add symarray

### DIFF
--- a/symengine/__init__.py
+++ b/symengine/__init__.py
@@ -3,7 +3,7 @@ from .lib.symengine_wrapper import (Symbol, Integer, sympify, SympifyError,
         have_mpfr, have_mpc, RealDouble, ComplexDouble, DenseMatrix,
         sin, cos, tan, cot, csc, sec, asin, acos, atan, acot, acsc, asec,
         sinh, cosh, tanh, coth, asinh, acosh, atanh, acoth, Lambdify,
-        LambdifyCSE, DictBasic, series)
+        LambdifyCSE, DictBasic, series, symarray)
 from .utilities import var, symbols
 
 if have_mpfr:

--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -577,6 +577,26 @@ cdef class Symbol(Basic):
         import sage.all as sage
         return sage.SR.symbol(str(deref(X).get_name().decode("utf-8")))
 
+
+def symarray(prefix, shape, **kwargs):
+    """ Creates an nd-array of symbols
+
+    Note that this function requires NumPy
+
+    Parameters
+    ----------
+    prefix: str
+    shape: tuple
+    Symbol: callable
+        (defualt :func:`Symbol`)
+    """
+    import numpy as np
+    arr = np.empty(shape, dtype=object)
+    for index in np.ndindex(shape):
+        arr[index] = Symbol('%s_%s' % (prefix, '_'.join(map(str, index))), **kwargs)
+    return arr
+
+
 cdef class Constant(Basic):
 
     def __cinit__(self, name = None):

--- a/symengine/tests/test_symbol.py
+++ b/symengine/tests/test_symbol.py
@@ -1,4 +1,4 @@
-from symengine import Symbol, symbols
+from symengine import Symbol, symbols, symarray
 from symengine.utilities import raises
 
 
@@ -125,3 +125,14 @@ def test_symbols():
     raises(ValueError, lambda: symbols('a::'))
     raises(ValueError, lambda: symbols(':a:'))
     raises(ValueError, lambda: symbols('::a'))
+
+
+def test_symarray():
+    try:
+        import numpy as np
+    except ImportError:
+        return
+    x0, x1, x2 = arr = symarray('x', 3)
+    assert arr.shape == (3,)
+
+    assert symarray('y', (2, 3)).shape == (2, 3)


### PR DESCRIPTION
This brings `symarray` to symengine (analogous to `sympy.symarray`). This makes it easier to write code that is agnostic to whether sympy or symengine is used directly.

Even though Symbol currently does not accept any keyword arguments I put kwargs there if it ever does (which one would likely forget to add to symarray then).