### PR TITLE
[skip ci] Rename csympy to symengine in benchmarks

### DIFF
--- a/benchmarks/expand1.py
+++ b/benchmarks/expand1.py
@@ -1,7 +1,7 @@
 import sys
 sys.path.append("..")
 from timeit import default_timer as clock
-from csympy import var
+from symengine import var
 var("x y z w")
 e = (x+y+z+w)**60
 t1 = clock()

--- a/benchmarks/expand3.py
+++ b/benchmarks/expand3.py
@@ -1,7 +1,7 @@
 import sys
 sys.path.append("..")
 from timeit import default_timer as clock
-from csympy import var
+from symengine import var
 var("x y z")
 f = (x**y + y**z + z**x)**100
 print f

--- a/benchmarks/expand4.py
+++ b/benchmarks/expand4.py
@@ -1,7 +1,7 @@
 import sys
 sys.path.append("..")
 from timeit import default_timer as clock
-from csympy import var
+from symengine import var
 var("x")
 e = 1
 for i in range(1, 351):

--- a/benchmarks/expand5.py
+++ b/benchmarks/expand5.py
@@ -1,7 +1,7 @@
 import sys
 sys.path.append("..")
 from timeit import default_timer as clock
-from csympy import var
+from symengine import var
 var("x y z")
 e = (x+y+z+1)**15
 f = e*(e+1)

--- a/benchmarks/kane.py
+++ b/benchmarks/kane.py
@@ -1,7 +1,7 @@
 import sys
 sys.path.append("..")
 from timeit import default_timer as clock
-from csympy import var, sympify, function_symbol, Symbol
+from symengine import var, sympify, function_symbol, Symbol
 import sympy
 s = open("expr.txt").read()
 print "Converting to SymPy..."

--- a/benchmarks/kane_generate.py
+++ b/benchmarks/kane_generate.py
@@ -250,9 +250,9 @@ def test_bicycle():
     # independent coordinates and speeds.
 
     e = KM._fr[0]
-    #import csympy
-    #print "Converting to csympy..."
-    #f = csympy.sympify(e)
+    #import symengine
+    #print "Converting to symengine..."
+    #f = symengine.sympify(e)
     print "Saving to expr.txt"
     s = str(e)
     open("expr.txt", "w").write(s)

--- a/benchmarks/legendre1.py
+++ b/benchmarks/legendre1.py
@@ -1,7 +1,7 @@
 import sys
 sys.path.append("..")
 from timeit import default_timer as clock
-from csympy import var, Integer
+from symengine import var, Integer
 
 def fact(n):
     if n in [0, 1]:

--- a/benchmarks/symbench.py
+++ b/benchmarks/symbench.py
@@ -2,14 +2,14 @@
 
 """
 Benchmarks listed at http://wiki.sagemath.org/symbench can be run using this script
-To run all benchmarks using csympy, sympy and sage, python symbench.py sympy sage
+To run all benchmarks using symengine, sympy and sage, python symbench.py sympy sage
 """
 
 import sys
 import subprocess
 
 benchmarks = ['R1', 'R2', 'R3', 'R5', 'S1', 'S2', 'S3', 'S3a']
-csympy_skip = [False, False, False, False, False, False, False, False]
+symengine_skip = [False, False, False, False, False, False, False, False]
 sympy_skip = [False, False, False, False, False, False, False, True]
 sage_skip = [False, False, False, False, False, False, False, False]
 
@@ -28,7 +28,7 @@ for i in range(len(benchmarks)):
     a = None
     b = None
     c = None
-    if not csympy_skip[i]:
+    if not symengine_skip[i]:
         a = subprocess.check_output(['python', 'symbench_def.py', benchmark])
         a = "\t SymEngine : " + a + " s"
     sys.stdout.write(a or ws)

--- a/benchmarks/symbench_def.py
+++ b/benchmarks/symbench_def.py
@@ -2,7 +2,7 @@
 
 """
 Benchmarks listed at http://wiki.sagemath.org/symbench can be run using this script
-To run the benchmark in csympy, run python symbench.py <benchmark_name>
+To run the benchmark in symengine, run python symbench.py <benchmark_name>
 To run the benchmark in sympy, run python symbench.py sympy <benchmark_name>
 """
 
@@ -15,7 +15,7 @@ if "sympy" in sys.argv:
     from sympy import sqrt, Integer, var, I, sin, cos
 else :
     is_sympy = False
-    from csympy import sqrt, Integer, var, I, sin, cos
+    from symengine import sqrt, Integer, var, I, sin, cos
 
 def R1():
     def f(z):

--- a/benchmarks/symbench_sage.py
+++ b/benchmarks/symbench_sage.py
@@ -2,7 +2,7 @@
 
 """
 Benchmarks listed at http://wiki.sagemath.org/symbench can be run using this script
-To run the benchmark in csympy, run python symbench.py <benchmark_name>
+To run the benchmark in symengine, run python symbench.py <benchmark_name>
 To run the benchmark in sympy, run python symbench.py sympy <benchmark_name>
 """
 


### PR DESCRIPTION
This change was done only in a few benchmarks previously. This replaces all occurences