### PR TITLE
Fix appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,7 +45,7 @@ install:
 - if [%COMPILER%]==[MinGW] set PATH=C:\MinGW\bin;%PATH%
 - if [%COMPILER%]==[MinGW] mingw-get update
 # workaround for https://github.com/appveyor/ci/issues/996
-- if [%COMPILER%]==[MinGW] mingw-get upgrade mingw32-libstdc++
+- if [%COMPILER%]==[MinGW] mingw-get upgrade libstdc++=4.9.3-1
 - if [%COMPILER%]==[MinGW] mingw-get install mingw32-gmp
 
 - if [%COMPILER%]==[MinGW-w64] set PATH=C:\mingw64\bin;%PATH%


### PR DESCRIPTION
MinGW updating of libstdc++ updated libstdc++ to a version newer than the gcc version. This installs libstdc++ version matching gcc version. This is temporary until appveyor/ci#996 is resolved.