### PR TITLE
Drop MinGW builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,6 +87,8 @@ matrix:
           - lrzip
 
 install:
+  # Workaround till symengine C++ repo's script is fixed
+  - if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then brew uninstall cmake; fi
   - export PYTHON_SOURCE_DIR=`pwd`
   - export TEST_CPP="no"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,12 +17,12 @@ environment:
       COMPILER: MSVC15
       PLATFORM: "x64"
       PYTHON_VERSION: 35-x64
-    - BUILD_TYPE: "Debug"
-      COMPILER: MinGW
-      PYTHON_VERSION: 27
-    - BUILD_TYPE: "Release"
-      COMPILER: MinGW
-      PYTHON_VERSION: 35
+#    - BUILD_TYPE: "Debug"
+#      COMPILER: MinGW
+#      PYTHON_VERSION: 27
+#    - BUILD_TYPE: "Release"
+#      COMPILER: MinGW
+#      PYTHON_VERSION: 35
     - BUILD_TYPE: "Release"
       COMPILER: MinGW-w64
       PYTHON_VERSION: 27-x64


### PR DESCRIPTION
I read about building python extensions with MinGW and there seems to be lots of problems with it. I'm surprised that we didn't have any problems till now. See https://mingwpy.github.io/issues.html#ms-gcc-abi-incompatibilities for more info. One thing we can do is try mingwpy. Till then I suggest dropping these tests. This seems to be a problem with 32 bit MinGW and MinGW-w64 64 bit builds still work.