### PR TITLE
In-place and out-of-tree builds using setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,13 @@ Python wrappers can be installed by,
 
 Additional options to setup.py are
 
-    python setup.py install build
+    python setup.py install build_ext
         --symengine-dir=/path/to/symengine/install/dir          # Path to SymEngine install directory or build directory
         --compiler=mingw32|msvc|cygwin                          # Select the compiler for Windows
         --generator=cmake-generator                             # CMake Generator
         --build-type=Release|Debug                              # Set build-type for multi-configuration generators like MSVC
         --define="var1=value1;var2=value2"                      # Give options to CMake
+        --inplace                                               # Build the extension in source tree
 
 Standard options to setup.py like `--user`, `--prefix` can be used to configure install location
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -83,9 +83,9 @@ install:
 
 build_script:
 
-- if [%COMPILER%]==[MSVC15] python setup.py install build --compiler=msvc --build-type=%BUILD_TYPE%
-- if [%COMPILER%]==[MinGW] python setup.py install build --compiler=mingw
-- if [%COMPILER%]==[MinGW-w64] python setup.py install build --compiler=mingw
+- if [%COMPILER%]==[MSVC15] python setup.py install build_ext --compiler=msvc --build-type=%BUILD_TYPE%
+- if [%COMPILER%]==[MinGW] python setup.py install build_ext --compiler=mingw --inplace
+- if [%COMPILER%]==[MinGW-w64] python setup.py install build_ext --compiler=mingw --inplace
 
 test_script:
 - if not [%COMPILER%]==[MSVC15] nosetests

--- a/bin/test_travis.sh
+++ b/bin/test_travis.sh
@@ -5,8 +5,8 @@ set -e
 # Echo each command
 set -x
 
-# Build and install python wrappers
-python setup.py install --symengine-dir=$our_install_dir
+# Build inplace so that nosetests can be run inside source directory
+python setup.py install build_ext --inplace --symengine-dir=$our_install_dir
 
 # Test python wrappers
 if [[ "${WITH_SAGE}" != "yes" ]]; then


### PR DESCRIPTION
Now, by default the build directory is `build/lib.<<arch>>-<<version>>` and therefore allows to build with several python versions in the same directory. eg. `python setup.py build && python3 setup.py build` works.

For old behaviour (building in the source directory) you can use `python setup.py build_ext --inplace`