### PR TITLE
Fixes for piranha integer

### DIFF
--- a/symengine/lib/symengine.pxd
+++ b/symengine/lib/symengine.pxd
@@ -21,7 +21,7 @@ cdef extern from 'symengine/mp_class.h' namespace "SymEngine":
         integer_class(int i)
         integer_class(integer_class)
         integer_class(mpz_t)
-        integer_class(const string &s, int base) except +
+        integer_class(const string &s) except +
     mpz_t get_mpz_t(integer_class &a)
     const mpz_t get_mpz_t(const integer_class &a)
     cdef cppclass rational_class:

--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -741,12 +741,12 @@ cdef class Integer(Number):
             # Too big, need to use mpz
             int_ok = False
             tmp = str(i).encode("utf-8")
-            i__ = symengine.integer_class(tmp, 10)
+            i__ = symengine.integer_class(tmp)
         # Note: all other exceptions are left intact
         if int_ok:
-            self.thisptr = symengine.make_rcp_Integer(i_)
+            self.thisptr = <RCP[const symengine.Basic]>symengine.integer(i_)
         else:
-            self.thisptr = symengine.make_rcp_Integer(i__)
+            self.thisptr = <RCP[const symengine.Basic]>symengine.integer(i__)
 
     def __hash__(self):
         return deref(self.thisptr).hash()


### PR DESCRIPTION
Issue is because piranha::integer has no implicit conversion from int

Fixes #102 