### PR TITLE
Define symengine_dir in InstallWithCmake

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -139,6 +139,8 @@ class InstallWithCmake(_install):
     def initialize_options(self):
         _install.initialize_options(self)
         self.define = None
+        self.symengine_dir = None
+        self.generator = None
         self.build_type = "Release"
 
     def finalize_options(self):


### PR DESCRIPTION
This was removed by mistake in #103