### PR TITLE
Basic._richcmp_(): Make Rel import global, not inline.

### DIFF
--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -13,6 +13,7 @@ from operator import mul
 from functools import reduce
 import collections
 import warnings
+from sympy import Rel
 
 include "config.pxi"
 
@@ -462,7 +463,6 @@ cdef class Basic(object):
         return Basic._richcmp_(A, B, op)
 
     def _richcmp_(Basic A, Basic B, int op):
-        from sympy import Rel
         if (op == 2):
             return symengine.eq(deref(A.thisptr), deref(B.thisptr))
         elif (op == 3):

--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -13,7 +13,6 @@ from operator import mul
 from functools import reduce
 import collections
 import warnings
-from sympy import Rel
 
 include "config.pxi"
 
@@ -467,7 +466,8 @@ cdef class Basic(object):
             return symengine.eq(deref(A.thisptr), deref(B.thisptr))
         elif (op == 3):
             return symengine.neq(deref(A.thisptr), deref(B.thisptr))
-        elif (op == 0):
+        from sympy import Rel
+        if (op == 0):
             return Rel(A, B, '<')
         elif (op == 1):
             return Rel(A, B, '<=')


### PR DESCRIPTION
This seems to have a major impact on comparison performance, e.g.:

Before:

```
>>> import timeit; timeit.timeit('a == b', 'from symengine import sympy_compat as sp; a = sp.Symbol("a"); b = sp.Symbol("b")', number=10000)
0.3318144249933539
```

After:

```
>>> import timeit; timeit.timeit('a == b', 'from symengine import sympy_compat as sp; a = sp.Symbol("a"); b = sp.Symbol("b")', number=10000)
0.0019199100061086938
```