### PR TITLE
Make symengine.py classes closer to sympy

### DIFF
--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -387,7 +387,7 @@ def get_dict(*args):
     return D
 
 
-cdef tuple vec_basic_to_tuple(symengine.vec_basic vec):
+cdef tuple vec_basic_to_tuple(symengine.vec_basic& vec):
     result = []
     for i in range(vec.size()):
         result.append(c2py(<RCP[const symengine.Basic]>(vec[i])))
@@ -1321,7 +1321,8 @@ cdef class Derivative(Basic):
 
     @property
     def expr(self):
-        return self.args[0]
+        cdef RCP[const symengine.Derivative] X = symengine.rcp_static_cast_Derivative(self.thisptr)
+        return c2py(deref(X).get_arg())
 
     @property
     def variables(self):
@@ -1376,17 +1377,20 @@ cdef class Subs(Basic):
 
     @property
     def expr(self):
-        return self.args[0]
+        cdef RCP[const symengine.Subs] me = symengine.rcp_static_cast_Subs(self.thisptr)
+        return c2py(deref(me).get_arg())
 
     @property
     def variables(self):
         cdef RCP[const symengine.Subs] me = symengine.rcp_static_cast_Subs(self.thisptr)
-        return vec_basic_to_tuple(deref(me).get_variables())
+        cdef symengine.vec_basic variables = deref(me).get_variables()
+        return vec_basic_to_tuple(variables)
 
     @property
     def point(self):
         cdef RCP[const symengine.Subs] me = symengine.rcp_static_cast_Subs(self.thisptr)
-        return vec_basic_to_tuple(deref(me).get_point())
+        cdef symengine.vec_basic point = deref(me).get_point()
+        return vec_basic_to_tuple(point)
 
     def _sympy_(self):
         cdef RCP[const symengine.Subs] X = symengine.rcp_static_cast_Subs(self.thisptr)

--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -846,6 +846,14 @@ cdef class Integer(Number):
     def __float__(self):
         return float(str(self))
 
+    @property
+    def p(self):
+        return int(self)
+
+    @property
+    def q(self):
+        return 1
+
 
 cdef class RealDouble(Number):
 

--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -661,8 +661,13 @@ cdef class Symbol(Basic):
         import sage.all as sage
         return sage.SR.symbol(str(deref(X).get_name().decode("utf-8")))
 
+    @property
     def name(self):
         return self.__str__()
+
+    @property
+    def is_Atom(self):
+        return True
 
     @property
     def is_Symbol(self):

--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -387,6 +387,13 @@ def get_dict(*args):
     return D
 
 
+cdef tuple vec_basic_to_tuple(symengine.vec_basic vec):
+    result = []
+    for i in range(vec.size()):
+        result.append(c2py(<RCP[const symengine.Basic]>(vec[i])))
+    return tuple(result)
+
+
 cdef class Basic(object):
 
     def __str__(self):
@@ -514,11 +521,8 @@ cdef class Basic(object):
 
     @property
     def args(self):
-        cdef symengine.vec_basic Y = deref(self.thisptr).get_args()
-        s = []
-        for i in range(Y.size()):
-            s.append(c2py(<RCP[const symengine.Basic]>(Y[i])))
-        return tuple(s)
+        cdef symengine.vec_basic args = deref(self.thisptr).get_args()
+        return vec_basic_to_tuple(args)
 
     @property
     def free_symbols(self):
@@ -1310,6 +1314,14 @@ cdef class Derivative(Basic):
     def is_Derivative(self):
         return True
 
+    @property
+    def expr(self):
+        return self.args[0]
+
+    @property
+    def variables(self):
+        return self.args[1:]
+
     def __cinit__(self, expr = None, symbols = None):
         if expr is None or symbols is None:
             return
@@ -1356,6 +1368,20 @@ cdef class Subs(Basic):
             p_ = sympify(p, True)
             m[v_.thisptr] = p_.thisptr
         self.thisptr = symengine.make_rcp_Subs(expr_.thisptr, m)
+
+    @property
+    def expr(self):
+        return self.args[0]
+
+    @property
+    def variables(self):
+        cdef RCP[const symengine.Subs] me = symengine.rcp_static_cast_Subs(self.thisptr)
+        return vec_basic_to_tuple(deref(me).get_variables())
+
+    @property
+    def point(self):
+        cdef RCP[const symengine.Subs] me = symengine.rcp_static_cast_Subs(self.thisptr)
+        return vec_basic_to_tuple(deref(me).get_point())
 
     def _sympy_(self):
         cdef RCP[const symengine.Subs] X = symengine.rcp_static_cast_Subs(self.thisptr)

--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -956,6 +956,14 @@ cdef class Rational(Number):
     def is_Rational(self):
         return True
 
+    @property
+    def p(self):
+        return self.get_num_den()[0]
+
+    @property
+    def q(self):
+        return self.get_num_den()[1]
+
     def get_num_den(self):
         cdef RCP[const symengine.Integer] _num, _den
         symengine.get_num_den(deref(symengine.rcp_static_cast_Rational(self.thisptr)),

--- a/symengine/tests/test_functions.py
+++ b/symengine/tests/test_functions.py
@@ -90,10 +90,11 @@ def test_Subs():
     assert Subs(Derivative(function_symbol("f", x, y), [x]), [x, y], [_x, x]) \
                 == Subs(Derivative(function_symbol("f", x, y), [x]), [y, x], [x, _x])
 
-    s = Subs(function_symbol("f", _x), [_x], [x])
-    assert s.expr == function_symbol("f", _x)
-    assert s.variables == (_x,)
-    assert s.point == (x,)
+    s = f.diff(x)/2
+    _xi_1 = Symbol("_xi_1")
+    assert s.expr == Derivative(function_symbol("f", _xi_1), [_xi_1])
+    assert s.variables == (_xi_1,)
+    assert s.point == (2*x,)
 
 def test_FunctionWrapper():
     import sympy

--- a/symengine/tests/test_functions.py
+++ b/symengine/tests/test_functions.py
@@ -56,6 +56,10 @@ def test_derivative():
     assert f.diff(x).diff(y) == function_symbol("f", x, y).diff(x).diff(y)
     assert f.diff(Symbol("z")) == 0
 
+    s = Derivative(function_symbol("f", x), [x])
+    assert s.expr == function_symbol("f", x)
+    assert s.variables == (x,)
+
 def test_abs():
     x = Symbol("x")
     e = abs(x)
@@ -85,6 +89,11 @@ def test_Subs():
     assert f.diff(x) == 2 * Subs(Derivative(function_symbol("f", _x), [_x]), [_x], [2 * x])
     assert Subs(Derivative(function_symbol("f", x, y), [x]), [x, y], [_x, x]) \
                 == Subs(Derivative(function_symbol("f", x, y), [x]), [y, x], [x, _x])
+
+    s = Subs(function_symbol("f", _x), [_x], [x])
+    assert s.expr == function_symbol("f", _x)
+    assert s.variables == (_x,)
+    assert s.point == (x,)
 
 def test_FunctionWrapper():
     import sympy

--- a/symengine/tests/test_symbol.py
+++ b/symengine/tests/test_symbol.py
@@ -4,6 +4,7 @@ from symengine.utilities import raises
 
 def test_symbol():
     x = Symbol("x")
+    assert x.name == "x"
     assert str(x) == "x"
     assert str(x) != "y"
     assert repr(x) == str(x)

--- a/symengine/tests/test_sympy_compat.py
+++ b/symengine/tests/test_sympy_compat.py
@@ -6,6 +6,8 @@ def test_Integer():
     assert isinstance(i, Integer)
     assert isinstance(i, Rational)
     assert isinstance(i, Basic)
+    assert i.p == 5
+    assert i.q == 1
 
 def test_Rational():
     i = S(1)/2

--- a/symengine/tests/test_sympy_compat.py
+++ b/symengine/tests/test_sympy_compat.py
@@ -11,6 +11,8 @@ def test_Rational():
     i = S(1)/2
     assert isinstance(i, Rational)
     assert isinstance(i, Basic)
+    assert i.p == 1
+    assert i.q == 2
 
 def test_Add():
     x, y = symbols("x y")


### PR DESCRIPTION
A bit of background: I'm working on [sumpy](https://github.com/inducer/sumpy), and we're interested in using symengine as a symbolic backend (currently we use sympy). These changes would help make the symengine transition a bit smoother.

These changes affect:

* Rational
* Derivative
* Subs
* Symbol

cc: @inducer