### PR TITLE
Sympy compat: add a functions submodule, add atan2

### DIFF
--- a/symengine/lib/symengine.pxd
+++ b/symengine/lib/symengine.pxd
@@ -256,6 +256,7 @@ cdef extern from "<symengine/basic.h>" namespace "SymEngine":
     bool is_a_ComplexMPC "SymEngine::is_a<SymEngine::ComplexMPC>"(const Basic &b) nogil
     bool is_a_Log "SymEngine::is_a<SymEngine::Log>"(const Basic &b) nogil
     bool is_a_PyNumber "SymEngine::is_a<SymEngine::PyNumber>"(const Basic &b) nogil
+    bool is_a_ATan2 "SymEngine::is_a<SymEngine::ATan2>"(const Basic &b) nogil
 
     RCP[const Basic] expand(RCP[const Basic] &o) nogil except +
 
@@ -417,6 +418,7 @@ cdef extern from "<symengine/functions.h>" namespace "SymEngine":
     cdef RCP[const Basic] function_symbol(string name, const vec_basic &arg) nogil except+
     cdef RCP[const Basic] abs(RCP[const Basic] &arg) nogil except+
     cdef RCP[const Basic] gamma(RCP[const Basic] &arg) nogil except+
+    cdef RCP[const Basic] atan2(RCP[const Basic] &num, RCP[const Basic] &den) nogil except+
 
     cdef cppclass Function(Basic):
         pass
@@ -510,6 +512,9 @@ cdef extern from "<symengine/functions.h>" namespace "SymEngine":
         RCP[const Basic] get_arg() nogil
 
     cdef cppclass Gamma(Function):
+        pass
+
+    cdef cppclass ATan2(Function):
         pass
 
 IF HAVE_SYMENGINE_MPFR:

--- a/symengine/lib/symengine_wrapper.pxd
+++ b/symengine/lib/symengine_wrapper.pxd
@@ -121,6 +121,9 @@ cdef class Abs(Function):
 cdef class Gamma(Function):
     pass
 
+cdef class ATan2(Function):
+    pass
+
 cdef class Derivative(Basic):
     pass
 

--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -99,6 +99,8 @@ cdef c2py(RCP[const symengine.Basic] o):
         r = ATanh.__new__(ATanh)
     elif (symengine.is_a_ACoth(deref(o))):
         r = ACoth.__new__(ACoth)
+    elif (symengine.is_a_ATan2(deref(o))):
+        r = ATan2.__new__(ATan2)
     elif (symengine.is_a_PyNumber(deref(o))):
         r = PyNumber.__new__(PyNumber)
     else:
@@ -169,6 +171,8 @@ def sympy2symengine(a, raise_error=False):
             return acsc(a.args[0])
         elif isinstance(a, sympy.asec):
             return asec(a.args[0])
+        elif isinstance(a, sympy.atan2):
+            return atan2(*a.args)
     elif isinstance(a, sympy.functions.elementary.hyperbolic.HyperbolicFunction):
         if isinstance(a, sympy.sinh):
             return sinh(a.args[0])
@@ -2158,6 +2162,11 @@ def log(x, y = None):
 def gamma(x):
     cdef Basic X = sympify(x)
     return c2py(symengine.gamma(X.thisptr))
+
+def atan2(x, y):
+    cdef Basic X = sympify(x)
+    cdef Basic Y = sympify(y)
+    return c2py(symengine.atan2(X.thisptr, Y.thisptr))
 
 def eval_double(x):
     cdef Basic X = sympify(x)

--- a/symengine/sympy_compat.py
+++ b/symengine/sympy_compat.py
@@ -240,6 +240,12 @@ class acoth(_RegisteredFunction):
         return symengine.acoth(a)
 
 
+class atan2(_RegisteredFunction):
+    _classes = (symengine.ATan2,)
+
+    def __new__(cls, a, b):
+        return symengine.atan2(a, b)
+
 '''
 for i in ("""Sin Cos Tan Gamma Cot Csc Sec ASin ACos ATan
           ACot ACsc ASec Sinh Cosh Tanh Coth ASinh ACosh ATanh

--- a/symengine/sympy_compat.py
+++ b/symengine/sympy_compat.py
@@ -4,7 +4,7 @@ from .compatibility import with_metaclass
 from .lib.symengine_wrapper import (Symbol, sympify, sympify as S,
         SympifyError, sqrt, I, E, pi, Matrix, Derivative, exp,
         Lambdify as lambdify, symarray, diff, zeros, eye, diag, ones, zeros,
-        expand, FunctionSymbol as AppliedUndef)
+        expand, Subs, FunctionSymbol as AppliedUndef)
 
 
 class BasicMeta(type):

--- a/symengine/sympy_compat.py
+++ b/symengine/sympy_compat.py
@@ -64,157 +64,181 @@ class Function(Basic):
         return symengine.UndefFunction(name)
 
 
-class log(Function):
+from types import ModuleType
+
+functions = ModuleType(__name__ + ".functions")
+import sys
+sys.modules[functions.__name__] = functions
+
+functions.sqrt = sqrt
+functions.exp = exp
+
+
+class _FunctionRegistrarMeta(BasicMeta):
+
+    def __new__(mcls, name, bases, dict):
+        cls = BasicMeta.__new__(mcls, name, bases, dict)
+        if not name.startswith("_"):
+            setattr(functions, name, cls)
+        return cls
+
+
+class _RegisteredFunction(with_metaclass(_FunctionRegistrarMeta, Function)):
+    pass
+
+
+class log(_RegisteredFunction):
     _classes = (symengine.Log,)
 
     def __new__(cls, a, b = E):
         return symengine.log(a, b)
 
 
-class sin(Function):
+class sin(_RegisteredFunction):
     _classes = (symengine.Sin,)
 
     def __new__(cls, a):
         return symengine.sin(a)
 
 
-class cos(Function):
+class cos(_RegisteredFunction):
     _classes = (symengine.Cos,)
 
     def __new__(cls, a):
         return symengine.cos(a)
 
 
-class tan(Function):
+class tan(_RegisteredFunction):
     _classes = (symengine.Tan,)
 
     def __new__(cls, a):
         return symengine.tan(a)
 
-class gamma(Function):
+class gamma(_RegisteredFunction):
     _classes = (symengine.Gamma,)
 
     def __new__(cls, a):
         return symengine.gamma(a)
 
 
-class cot(Function):
+class cot(_RegisteredFunction):
     _classes = (symengine.Cot,)
 
     def __new__(cls, a):
         return symengine.cot(a)
 
 
-class csc(Function):
+class csc(_RegisteredFunction):
     _classes = (symengine.Csc,)
 
     def __new__(cls, a):
         return symengine.csc(a)
 
 
-class sec(Function):
+class sec(_RegisteredFunction):
     _classes = (symengine.Sec,)
 
     def __new__(cls, a):
         return symengine.sec(a)
 
 
-class asin(Function):
+class asin(_RegisteredFunction):
     _classes = (symengine.ASin,)
 
     def __new__(cls, a):
         return symengine.asin(a)
 
 
-class acos(Function):
+class acos(_RegisteredFunction):
     _classes = (symengine.ACos,)
 
     def __new__(cls, a):
         return symengine.acos(a)
 
 
-class atan(Function):
+class atan(_RegisteredFunction):
     _classes = (symengine.ATan,)
 
     def __new__(cls, a):
         return symengine.atan(a)
 
 
-class acot(Function):
+class acot(_RegisteredFunction):
     _classes = (symengine.ACot,)
 
     def __new__(cls, a):
         return symengine.acot(a)
 
 
-class acsc(Function):
+class acsc(_RegisteredFunction):
     _classes = (symengine.ACsc,)
 
     def __new__(cls, a):
         return symengine.acsc(a)
 
 
-class asec(Function):
+class asec(_RegisteredFunction):
     _classes = (symengine.ASec,)
 
     def __new__(cls, a):
         return symengine.asec(a)
 
 
-class sinh(Function):
+class sinh(_RegisteredFunction):
     _classes = (symengine.Sinh,)
 
     def __new__(cls, a):
         return symengine.sinh(a)
 
 
-class cosh(Function):
+class cosh(_RegisteredFunction):
     _classes = (symengine.Cosh,)
 
     def __new__(cls, a):
         return symengine.cosh(a)
 
 
-class tanh(Function):
+class tanh(_RegisteredFunction):
     _classes = (symengine.Tanh,)
 
     def __new__(cls, a):
         return symengine.tanh(a)
 
 
-class coth(Function):
+class coth(_RegisteredFunction):
     _classes = (symengine.Coth,)
 
     def __new__(cls, a):
         return symengine.coth(a)
 
 
-class asinh(Function):
+class asinh(_RegisteredFunction):
     _classes = (symengine.ASinh,)
 
     def __new__(cls, a):
         return symengine.asinh(a)
 
 
-class acosh(Function):
+class acosh(_RegisteredFunction):
     _classes = (symengine.ACosh,)
 
     def __new__(cls, a):
         return symengine.acosh(a)
 
 
-class atanh(Function):
+class atanh(_RegisteredFunction):
     _classes = (symengine.ATanh,)
 
     def __new__(cls, a):
         return symengine.atanh(a)
 
 
-class acoth(Function):
+class acoth(_RegisteredFunction):
     _classes = (symengine.ACoth,)
 
     def __new__(cls, a):
         return symengine.acoth(a)
+
 
 '''
 for i in ("""Sin Cos Tan Gamma Cot Csc Sec ASin ACos ATan

--- a/symengine/tests/test_sympy_compat.py
+++ b/symengine/tests/test_sympy_compat.py
@@ -53,3 +53,6 @@ def test_log():
 def test_zeros():
     assert zeros(3, c=2).shape == (3, 2)
 
+def test_has_functions_module():
+    import symengine.sympy_compat as sp
+    assert sp.functions.sin(0) == 0

--- a/symengine/tests/test_sympy_compat.py
+++ b/symengine/tests/test_sympy_compat.py
@@ -1,5 +1,5 @@
 from symengine.sympy_compat import (Integer, Rational, S, Basic, Add, Mul,
-    Pow, symbols, Symbol, log, sin, zeros)
+    Pow, symbols, Symbol, log, sin, zeros, atan2)
 
 def test_Integer():
     i = Integer(5)
@@ -49,6 +49,13 @@ def test_log():
     assert isinstance(i, Mul)
     i = log(x)
     assert isinstance(i, log)
+
+def test_ATan2():
+    x, y = symbols("x y")
+    i = atan2(x, y)
+    assert isinstance(i, atan2)
+    i = atan2(0, 1)
+    assert i == 0
 
 def test_zeros():
     assert zeros(3, c=2).shape == (3, 2)


### PR DESCRIPTION
This PR is similar to #117 in that it intends to make things closer to sympy, but it contains changes to sympy-compat.

Summary:
* Adds a module sympy_compat.functions
* Imports Subs into sympy_compat
* Adds atan2 support

cc: @inducer