### PR TITLE
Allow subclasses of Symbol

### DIFF
--- a/symengine/lib/symengine.pxd
+++ b/symengine/lib/symengine.pxd
@@ -130,6 +130,7 @@ cdef extern from "<symengine/symengine_rcp.h>" namespace "SymEngine":
         T& operator*() nogil except +
 
     RCP[const Symbol] rcp_static_cast_Symbol "SymEngine::rcp_static_cast<const SymEngine::Symbol>"(RCP[const Basic] &b) nogil
+    RCP[const PySymbol] rcp_static_cast_PySymbol "SymEngine::rcp_static_cast<const SymEngine::PySymbol>"(RCP[const Basic] &b) nogil
     RCP[const Integer] rcp_static_cast_Integer "SymEngine::rcp_static_cast<const SymEngine::Integer>"(RCP[const Basic] &b) nogil
     RCP[const Rational] rcp_static_cast_Rational "SymEngine::rcp_static_cast<const SymEngine::Rational>"(RCP[const Basic] &b) nogil
     RCP[const Complex] rcp_static_cast_Complex "SymEngine::rcp_static_cast<const SymEngine::Complex>"(RCP[const Basic] &b) nogil
@@ -257,6 +258,7 @@ cdef extern from "<symengine/basic.h>" namespace "SymEngine":
     bool is_a_Log "SymEngine::is_a<SymEngine::Log>"(const Basic &b) nogil
     bool is_a_PyNumber "SymEngine::is_a<SymEngine::PyNumber>"(const Basic &b) nogil
     bool is_a_ATan2 "SymEngine::is_a<SymEngine::ATan2>"(const Basic &b) nogil
+    bool is_a_PySymbol "SymEngine::is_a_sub<SymEngine::PySymbol>"(const Basic &b) nogil
 
     RCP[const Basic] expand(RCP[const Basic] &o) nogil except +
 
@@ -290,6 +292,11 @@ cdef extern from "<symengine/pywrapper.h>" namespace "SymEngine":
     cdef cppclass PyFunctionClass:
         PyObject* call(const vec_basic &vec)
     cdef cppclass PyFunction:
+        PyObject* get_py_object()
+
+cdef extern from "<symengine/pywrapper.h>" namespace "SymEngine":
+    cdef cppclass PySymbol(Symbol):
+        PySymbol(string name, PyObject* pyobj)
         PyObject* get_py_object()
 
 cdef extern from "<symengine/integer.h>" namespace "SymEngine":
@@ -376,6 +383,7 @@ cdef extern from "<symengine/pow.h>" namespace "SymEngine":
 cdef extern from "<symengine/basic.h>" namespace "SymEngine":
     # We need to specialize these for our classes:
     RCP[const Basic] make_rcp_Symbol "SymEngine::make_rcp<const SymEngine::Symbol>"(string name) nogil
+    RCP[const Basic] make_rcp_PySymbol "SymEngine::make_rcp<const SymEngine::PySymbol>"(string name, PyObject * pyobj) nogil
     RCP[const Basic] make_rcp_Constant "SymEngine::make_rcp<const SymEngine::Constant>"(string name) nogil
     RCP[const Basic] make_rcp_Integer "SymEngine::make_rcp<const SymEngine::Integer>"(int i) nogil
     RCP[const Basic] make_rcp_Integer "SymEngine::make_rcp<const SymEngine::Integer>"(integer_class i) nogil

--- a/symengine/sympy_compat.py
+++ b/symengine/sympy_compat.py
@@ -1,7 +1,7 @@
 from .lib import symengine_wrapper as symengine
 from .utilities import var, symbols
 from .compatibility import with_metaclass
-from .lib.symengine_wrapper import (Symbol, sympify, sympify as S,
+from .lib.symengine_wrapper import (sympify, sympify as S,
         SympifyError, sqrt, I, E, pi, Matrix, Derivative, exp,
         Lambdify as lambdify, symarray, diff, zeros, eye, diag, ones, zeros,
         expand, Subs, FunctionSymbol as AppliedUndef)
@@ -18,19 +18,23 @@ class Basic(with_metaclass(BasicMeta, object)):
 
 
 class Number(Basic):
-    _classes = (symengine.Number,) + Basic._classes
+    _classes = (symengine.Number,)
+    pass
+
+class Symbol(symengine.PySymbol, Basic):
+    _classes = (symengine.Symbol,)
     pass
 
 
 class Rational(Number):
-    _classes = (symengine.Rational,) + Number._classes
+    _classes = (symengine.Rational, symengine.Integer)
 
     def __new__(cls, num, den = 1):
         return symengine.Integer(num) / den
 
 
 class Integer(Rational):
-    _classes = (symengine.Integer,) + Rational._classes
+    _classes = (symengine.Integer,)
 
     def __new__(cls, i):
         return symengine.Integer(i)

--- a/symengine/tests/test_sympy_compat.py
+++ b/symengine/tests/test_sympy_compat.py
@@ -73,7 +73,7 @@ def test_has_functions_module():
     import symengine.sympy_compat as sp
     assert sp.functions.sin(0) == 0
 
-def subclass_symbol():
+def test_subclass_symbol():
     # Subclass of Symbol with an extra attribute
     class Wrapper(Symbol):
         def __new__(cls, name, extra_attribute):

--- a/symengine/tests/test_sympy_compat.py
+++ b/symengine/tests/test_sympy_compat.py
@@ -1,10 +1,11 @@
 from symengine.sympy_compat import (Integer, Rational, S, Basic, Add, Mul,
-    Pow, symbols, Symbol, log, sin, zeros, atan2)
+    Pow, symbols, Symbol, log, sin, zeros, atan2, Number)
 
 def test_Integer():
     i = Integer(5)
     assert isinstance(i, Integer)
     assert isinstance(i, Rational)
+    assert isinstance(i, Number)
     assert isinstance(i, Basic)
     assert i.p == 5
     assert i.q == 1
@@ -12,9 +13,13 @@ def test_Integer():
 def test_Rational():
     i = S(1)/2
     assert isinstance(i, Rational)
+    assert isinstance(i, Number)
     assert isinstance(i, Basic)
     assert i.p == 1
     assert i.q == 2
+    x = symbols("x")
+    assert not isinstance(x, Rational)
+    assert not isinstance(x, Number)
 
 def test_Add():
     x, y = symbols("x y")
@@ -67,3 +72,21 @@ def test_zeros():
 def test_has_functions_module():
     import symengine.sympy_compat as sp
     assert sp.functions.sin(0) == 0
+
+def subclass_symbol():
+    # Subclass of Symbol with an extra attribute
+    class Wrapper(Symbol):
+        def __new__(cls, name, extra_attribute):
+            return Symbol.__new__(cls, name)
+
+        def __init__(self, name, extra_attribute):
+            super(Wrapper, self).__init__(name)
+            self.extra_attribute = extra_attribute
+
+    # Instantiate the subclass
+    x = Wrapper("x", extra_attribute=3)
+    assert x.extra_attribute == 3
+    two_x = 2 * x
+    # Check that after arithmetic, same subclass is returned
+    assert two_x.args[1] is x
+


### PR DESCRIPTION
Fixes #123.

@KristianJensen, you can do the following now

```python
import symengine.sympy_compat as symengine

class Wrapper(symengine.Symbol):
    def __new__(cls, name, extra_attribute):
        return symengine.Symbol.__new__(cls, name)

    def __init__(self, name, extra_attribute):
        super(Wrapper, self).__init__(name)
        self.extra_attribute = extra_attribute

# Instantiate the subclass
x = Wrapper("x", extra_attribute=3)
assert x.extra_attribute == 3
two_x = 2 * x
# Check that after arithmetic, same subclass is returned
assert two_x.args[1] is x
```