### PR TITLE
Use the parser to sympify strings

### DIFF
--- a/symengine/lib/symengine.pxd
+++ b/symengine/lib/symengine.pxd
@@ -770,3 +770,6 @@ IF HAVE_SYMENGINE_MPFR:
 IF HAVE_SYMENGINE_MPC:
     cdef extern from "<symengine/eval_mpc.h>" namespace "SymEngine":
         void eval_mpc(mpc_t result, const Basic &b, mpfr_rnd_t rnd) nogil except +
+
+cdef extern from "<symengine/parser.h>" namespace "SymEngine":
+    RCP[const Basic] parse(const string &n) nogil except +

--- a/symengine/tests/test_sympify.py
+++ b/symengine/tests/test_sympify.py
@@ -1,6 +1,7 @@
 from symengine.utilities import raises
 
 from symengine import Symbol, Integer, sympify, SympifyError
+from symengine.lib.symengine_wrapper import _sympify
 
 
 def test_sympify1():
@@ -8,23 +9,19 @@ def test_sympify1():
     assert sympify(2) != Integer(1)
     assert sympify(-5) == Integer(-5)
     assert sympify(Integer(3)) == Integer(3)
+    assert sympify("3+5") == Integer(8)
 
 
 def test_sympify_error1a():
-    raises(SympifyError, lambda: sympify("if"))
+    class Test(object):
+        pass
+    raises(SympifyError, lambda: sympify(Test()))
 
 
 def test_sympify_error1b():
-    assert not sympify("if", raise_error=False)
+    assert not _sympify("1***2", raise_error=False)
 
 
 def test_error1():
-    raises(SympifyError, lambda: sympify("x"))
-
-
-def test_error2():
-    raises(SympifyError, lambda: sympify("   x"))
-
-
-def test_error3():
-    raises(SympifyError, lambda: sympify("   x   "))
+    # _sympify doesn't parse strings
+    raises(SympifyError, lambda: _sympify("x"))


### PR DESCRIPTION
Also use _sympify internally which doesn't parse strings to avoid
statements like sympify(1) + "a" getting accepted.