### PR TITLE
fix of missing order-parameter in LambdifyCSE

### DIFF
--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -4741,7 +4741,7 @@ def LambdifyCSE(args, *exprs, cse=None, order='C', **kwargs):
                                         expr.shape, order=order))
             n_taken += expr.size
         new_lmb = Lambdify(tuple(_args) + cse_symbs, *new_exprs, order=order, **kwargs)
-        cse_lambda = Lambdify(_args, [ce.xreplace(explicit_subs) for ce in cse_exprs], **kwargs)
+        cse_lambda = Lambdify(_args, [ce.xreplace(explicit_subs) for ce in cse_exprs], order=order, **kwargs)
         def cb(inp, *, out=None, **kw):
             _inp = np.asanyarray(inp)
             cse_vals = cse_lambda(_inp, **kw)
@@ -4754,7 +4754,7 @@ def LambdifyCSE(args, *exprs, cse=None, order='C', **kwargs):
             return new_lmb(new_inp, out=out, **kw)
         return cb
     else:
-        return Lambdify(args, *exprs, **kwargs)
+        return Lambdify(args, *exprs, order=order, **kwargs)
 
 
 def ccode(expr):


### PR DESCRIPTION
since i really wanted to use this function, i gave it a quick try if i find something suspicious...

- the newly introduced order-argument was missing in two calls of Lambify()
which consequently results in an error once it is changed to a non-default value

- this finally fixes the remaining parts of the issue #174