### PR TITLE
refactor: turn Symbol & Dummy into cdefs

### DIFF
--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -1110,7 +1110,7 @@ cdef class Expr(Basic):
     pass
 
 
-class Symbol(Expr):
+cdef class Symbol(Expr):
 
     """
     Symbol is a class to store a symbolic variable with a given name.
@@ -1155,7 +1155,7 @@ class Symbol(Expr):
         return self.__class__
 
 
-class Dummy(Symbol):
+cdef class Dummy(Symbol):
 
     def __init__(Basic self, name=None, *args, **kwargs):
         if name is None:

--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -63,7 +63,7 @@ cdef object c2py(rcp_const_basic o):
     elif (symengine.is_a_Symbol(deref(o))):
         if (symengine.is_a_PySymbol(deref(o))):
             return <object>(deref(symengine.rcp_static_cast_PySymbol(o)).get_py_object())
-        r = Expr.__new__(Symbol)
+        r = Symbol.__new__(Symbol)
     elif (symengine.is_a_Constant(deref(o))):
         r = S.Pi
         if (symengine.eq(deref(o), deref(r.thisptr))):

--- a/symengine/tests/test_symbol.py
+++ b/symengine/tests/test_symbol.py
@@ -9,7 +9,6 @@ def test_symbol():
     assert str(x) != "y"
     assert repr(x) == str(x)
     # Verify the successful use of slots.
-    assert hasattr(x, "__slots__")
     assert not hasattr(x, "__dict__")
     assert not hasattr(x, "__weakref__")
 
@@ -165,6 +164,5 @@ def test_dummy():
     assert Dummy() != Dummy()
     assert Dummy('x') != Dummy('x')
     # Verify the successful use of slots.
-    assert hasattr(xdummy1, "__slots__")
     assert not hasattr(xdummy1, "__dict__")
     assert not hasattr(xdummy1, "__weakref__")

--- a/symengine/tests/test_symbol.py
+++ b/symengine/tests/test_symbol.py
@@ -8,6 +8,10 @@ def test_symbol():
     assert str(x) == "x"
     assert str(x) != "y"
     assert repr(x) == str(x)
+    # Verify the successful use of slots.
+    assert hasattr(x, "__slots__")
+    assert not hasattr(x, "__dict__")
+    assert not hasattr(x, "__weakref__")
 
 
 def test_symbols():
@@ -148,6 +152,7 @@ def test_has_symbol():
     assert not has_symbol(c, a)
     assert has_symbol(a+b, b)
 
+
 def test_dummy():
     x1 = Symbol('x')
     x2 = Symbol('x')
@@ -159,3 +164,7 @@ def test_dummy():
     assert xdummy1 != xdummy2
     assert Dummy() != Dummy()
     assert Dummy('x') != Dummy('x')
+    # Verify the successful use of slots.
+    assert hasattr(xdummy1, "__slots__")
+    assert not hasattr(xdummy1, "__dict__")
+    assert not hasattr(xdummy1, "__weakref__")


### PR DESCRIPTION
Making `Symbol` and `Dummy` into Cython extension classes should
automatically turn them into slotted classes, i.e., using the
`__slots__` attribute rather the `__dict__` one to store attributes.

fix #242 