### PR TITLE
LambdaDouble and LLVMDouble as cimport-able types

### DIFF
--- a/symengine/lib/symengine_wrapper.pxd
+++ b/symengine/lib/symengine_wrapper.pxd
@@ -1,5 +1,8 @@
 cimport symengine
 from symengine cimport RCP, map_basic_basic, rcp_const_basic
+from libcpp.vector cimport vector
+from libcpp.string cimport string
+from libcpp cimport bool as cppbool
 
 cdef class Basic(object):
     cdef rcp_const_basic thisptr
@@ -22,3 +25,37 @@ cdef class DictBasicIter(object):
     cdef init(self, map_basic_basic.iterator begin, map_basic_basic.iterator end)
 
 cdef object c2py(rcp_const_basic o)
+
+cdef class _Lambdify(object):
+    cdef size_t args_size, tot_out_size
+    cdef list out_shapes
+    cdef readonly bint real
+    cdef readonly size_t n_exprs
+    cdef public str order
+    cdef vector[int] accum_out_sizes
+    cdef object numpy_dtype
+
+    cdef _init(self, symengine.vec_basic& args_, symengine.vec_basic& outs_, cppbool cse)
+    cdef _load(self, const string &s)
+    cpdef unsafe_real(self,
+                      double[::1] inp, double[::1] out,
+                      int inp_offset=*, int out_offset=*)
+    cpdef unsafe_complex(self, double complex[::1] inp, double complex[::1] out,
+                         int inp_offset=*, int out_offset=*)
+    cpdef eval_real(self, inp, out)
+    cpdef eval_complex(self, inp, out)
+
+cdef class LambdaDouble(_Lambdify):
+    cdef vector[symengine.LambdaRealDoubleVisitor] lambda_double
+    cdef vector[symengine.LambdaComplexDoubleVisitor] lambda_double_complex
+    cdef _init(self, symengine.vec_basic& args_, symengine.vec_basic& outs_, cppbool cse)
+    cpdef unsafe_real(self, double[::1] inp, double[::1] out, int inp_offset=*, int out_offset=*)
+    cpdef unsafe_complex(self, double complex[::1] inp, double complex[::1] out, int inp_offset=*, int out_offset=*)
+    cpdef as_scipy_low_level_callable(self)
+
+cdef class LLVMDouble(_Lambdify):
+    cdef vector[symengine.LLVMDoubleVisitor] lambda_double
+    cdef _init(self, symengine.vec_basic& args_, symengine.vec_basic& outs_, cppbool cse)
+    cdef _load(self, const string &s)
+    cpdef unsafe_real(self, double[::1] inp, double[::1] out, int inp_offset=*, int out_offset=*)
+    cpdef as_scipy_low_level_callable(self)

--- a/symengine/lib/symengine_wrapper.pxd
+++ b/symengine/lib/symengine_wrapper.pxd
@@ -4,6 +4,8 @@ from libcpp.vector cimport vector
 from libcpp.string cimport string
 from libcpp cimport bool as cppbool
 
+include "config.pxi"
+
 cdef class Basic(object):
     cdef rcp_const_basic thisptr
 
@@ -53,9 +55,10 @@ cdef class LambdaDouble(_Lambdify):
     cpdef unsafe_complex(self, double complex[::1] inp, double complex[::1] out, int inp_offset=*, int out_offset=*)
     cpdef as_scipy_low_level_callable(self)
 
-cdef class LLVMDouble(_Lambdify):
-    cdef vector[symengine.LLVMDoubleVisitor] lambda_double
-    cdef _init(self, symengine.vec_basic& args_, symengine.vec_basic& outs_, cppbool cse)
-    cdef _load(self, const string &s)
-    cpdef unsafe_real(self, double[::1] inp, double[::1] out, int inp_offset=*, int out_offset=*)
-    cpdef as_scipy_low_level_callable(self)
+IF HAVE_SYMENGINE_LLVM:
+    cdef class LLVMDouble(_Lambdify):
+        cdef vector[symengine.LLVMDoubleVisitor] lambda_double
+        cdef _init(self, symengine.vec_basic& args_, symengine.vec_basic& outs_, cppbool cse)
+        cdef _load(self, const string &s)
+        cpdef unsafe_real(self, double[::1] inp, double[::1] out, int inp_offset=*, int out_offset=*)
+        cpdef as_scipy_low_level_callable(self)

--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -4452,14 +4452,6 @@ def has_symbol(obj, symbol=None):
 
 
 cdef class _Lambdify(object):
-    cdef size_t args_size, tot_out_size
-    cdef list out_shapes
-    cdef readonly bint real
-    cdef readonly size_t n_exprs
-    cdef public str order
-    cdef vector[int] accum_out_sizes
-    cdef object numpy_dtype
-
     def __init__(self, args, *exprs, cppbool real=True, order='C', cppbool cse=False, cppbool _load=False):
         cdef:
             Basic e_
@@ -4690,10 +4682,6 @@ def create_low_level_callable(lambdify, *args):
 
 
 cdef class LambdaDouble(_Lambdify):
-
-    cdef vector[symengine.LambdaRealDoubleVisitor] lambda_double
-    cdef vector[symengine.LambdaComplexDoubleVisitor] lambda_double_complex
-
     cdef _init(self, symengine.vec_basic& args_, symengine.vec_basic& outs_, cppbool cse):
         if self.real:
             self.lambda_double.resize(1)
@@ -4722,9 +4710,6 @@ cdef class LambdaDouble(_Lambdify):
 
 IF HAVE_SYMENGINE_LLVM:
     cdef class LLVMDouble(_Lambdify):
-
-        cdef vector[symengine.LLVMDoubleVisitor] lambda_double
-
         cdef _init(self, symengine.vec_basic& args_, symengine.vec_basic& outs_, cppbool cse):
             self.lambda_double.resize(1)
             self.lambda_double[0].init(args_, outs_, cse)


### PR DESCRIPTION
This PR adds `LLVMDouble` and `LambdaDouble` to the type definition file for `symengine_wrapper`. The major advantage is that downstream Cython modules can access the `lambda_double` attribute to directly call the `LLVMDoubleVisitor` or `Lambda[Real/Complex]DoubleVisitor` without hitting the GIL (those types are already declared in `symengine.pxd`).

No new tests should be required, since Cython will refuse to compile when the type definition and implementation are inconsistent.