### PR TITLE
LambdaDouble/LLVMDouble: Add cdef nogil function wrappers for fast calling

### DIFF
--- a/symengine/lib/symengine_wrapper.pxd
+++ b/symengine/lib/symengine_wrapper.pxd
@@ -39,9 +39,11 @@ cdef class _Lambdify(object):
 
     cdef _init(self, symengine.vec_basic& args_, symengine.vec_basic& outs_, cppbool cse)
     cdef _load(self, const string &s)
+    cdef void unsafe_real_ptr(self, double *inp, double *out) nogil
     cpdef unsafe_real(self,
                       double[::1] inp, double[::1] out,
                       int inp_offset=*, int out_offset=*)
+    cdef void unsafe_complex_ptr(self, double complex *inp, double complex *out) nogil
     cpdef unsafe_complex(self, double complex[::1] inp, double complex[::1] out,
                          int inp_offset=*, int out_offset=*)
     cpdef eval_real(self, inp, out)
@@ -51,7 +53,9 @@ cdef class LambdaDouble(_Lambdify):
     cdef vector[symengine.LambdaRealDoubleVisitor] lambda_double
     cdef vector[symengine.LambdaComplexDoubleVisitor] lambda_double_complex
     cdef _init(self, symengine.vec_basic& args_, symengine.vec_basic& outs_, cppbool cse)
+    cdef void unsafe_real_ptr(self, double *inp, double *out) nogil
     cpdef unsafe_real(self, double[::1] inp, double[::1] out, int inp_offset=*, int out_offset=*)
+    cdef void unsafe_complex_ptr(self, double complex *inp, double complex *out) nogil
     cpdef unsafe_complex(self, double complex[::1] inp, double complex[::1] out, int inp_offset=*, int out_offset=*)
     cpdef as_scipy_low_level_callable(self)
 
@@ -60,5 +64,6 @@ IF HAVE_SYMENGINE_LLVM:
         cdef vector[symengine.LLVMDoubleVisitor] lambda_double
         cdef _init(self, symengine.vec_basic& args_, symengine.vec_basic& outs_, cppbool cse)
         cdef _load(self, const string &s)
+        cdef void unsafe_real_ptr(self, double *inp, double *out) nogil
         cpdef unsafe_real(self, double[::1] inp, double[::1] out, int inp_offset=*, int out_offset=*)
         cpdef as_scipy_low_level_callable(self)

--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -4517,7 +4517,8 @@ cdef class _Lambdify(object):
         raise ValueError("Not supported")
 
     cdef void unsafe_complex_ptr(self, double complex *inp, double complex *out) nogil:
-        raise ValueError("Not supported")
+        with gil:
+            raise ValueError("Not supported")
 
     cpdef unsafe_complex(self, double complex[::1] inp, double complex[::1] out,
                          int inp_offset=0, int out_offset=0):

--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -4508,7 +4508,8 @@ cdef class _Lambdify(object):
         raise ValueError("Not supported")
 
     cdef void unsafe_real_ptr(self, double *inp, double *out) nogil:
-        raise ValueError("Not supported")
+        with gil:
+            raise ValueError("Not supported")
 
     cpdef unsafe_real(self,
                       double[::1] inp, double[::1] out,


### PR DESCRIPTION
This adds new `unsafe_*_ptr` member functions to LambdaDouble and LLVMDouble, corresponding to existing `unsafe_*` functions. These new functions are marked `nogil`. The purpose of this is to provide fast access to the underlying visitor object's `call` function without requiring downstream code to link to libsymengine.

These additions are made in a way to preserve API compatibility with existing code. The `unsafe_*` functions are modified to call `unsafe_*_ptr` under the hood, to ensure the code path stays functional and is hit during tests.