### PR TITLE
Fix DeprecationWarning for MutableMapping import

### DIFF
--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -19,6 +19,12 @@ import collections
 import warnings
 from symengine.compatibility import is_sequence
 import os
+import sys
+
+if sys.version_info[0] == 2:
+    from collections import MutableMapping
+else:
+    from collections.abc import MutableMapping
 
 try:
     import numpy as np
@@ -720,7 +726,7 @@ cdef class _DictBasic(object):
         return d
 
 
-class DictBasic(_DictBasic, collections.MutableMapping):
+class DictBasic(_DictBasic, MutableMapping):
 
     def __str__(self):
         return "{" + ", ".join(["%s: %s" % (str(key), str(value)) for key, value in self.items()]) + "}"


### PR DESCRIPTION
This PR fixes a `DeprecationWarning` issued when running under Python 3 because SymEngine uses abstract base classes imported directly from `collections` instead of `collections.abc`. The abstract base classes were moved in 3.3 and the old way of importing them directly from `collections` will stop working in 3.8.

Running the following prints the `DeprecationWarning` when importing SymEngine:

```
$ python -Wall
Python 3.7.0 (default, Oct 22 2018, 09:00:22)
[Clang 9.0.0 (clang-900.0.39.2)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import symengine
/Users/erik/[...]/python3.7/site-packages/symengine/__init__.py:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working                                                                  
  from .lib.symengine_wrapper import (
```

(See also [Python's documentation](https://docs.python.org/3/library/collections.html) for the official deprecation note.)