### PR TITLE
Pass symengine object with PyCapsule

### DIFF
--- a/symengine/lib/symengine.pxd
+++ b/symengine/lib/symengine.pxd
@@ -10,6 +10,7 @@ include "config.pxi"
 cdef extern from 'symengine/cwrapper.h':
     ctypedef struct basic_struct:
         pass
+    ctypedef basic_struct basic[1]
 
 cdef extern from 'symengine/mp_class.h' namespace "SymEngine":
     ctypedef unsigned long mp_limb_t

--- a/symengine/lib/symengine.pxd
+++ b/symengine/lib/symengine.pxd
@@ -1066,6 +1066,6 @@ cdef extern from "<symengine/printers.h>" namespace "SymEngine":
     string latex(const Basic &x) nogil except +
 
 cdef extern from 'symengine/cwrapper.h':
-    ctypedef struct CRCPBasic:
+    cdef struct CRCPBasic:
         rcp_const_basic m
     ctypedef CRCPBasic basic[1]

--- a/symengine/lib/symengine.pxd
+++ b/symengine/lib/symengine.pxd
@@ -8,9 +8,9 @@ from libcpp.pair cimport pair
 include "config.pxi"
 
 cdef extern from 'symengine/cwrapper.h':
-    ctypedef struct basic_struct:
-        pass
-    ctypedef basic_struct basic[1]
+    ctypedef struct CRCPBasic:
+        rcp_const_basic m
+    ctypedef CRCPBasic basic[1]
 
 cdef extern from 'symengine/mp_class.h' namespace "SymEngine":
     ctypedef unsigned long mp_limb_t

--- a/symengine/lib/symengine.pxd
+++ b/symengine/lib/symengine.pxd
@@ -1065,7 +1065,8 @@ cdef extern from "<symengine/printers.h>" namespace "SymEngine":
     string ccode(const Basic &x) nogil except +
     string latex(const Basic &x) nogil except +
 
+cdef struct CRCPBasic:
+    rcp_const_basic m
+
 cdef extern from 'symengine/cwrapper.h':
-    cdef struct CRCPBasic:
-        rcp_const_basic m
     ctypedef CRCPBasic basic[1]

--- a/symengine/lib/symengine.pxd
+++ b/symengine/lib/symengine.pxd
@@ -1065,8 +1065,6 @@ cdef extern from "<symengine/printers.h>" namespace "SymEngine":
     string ccode(const Basic &x) nogil except +
     string latex(const Basic &x) nogil except +
 
+## Defined in 'symengine/cwrapper.cpp'
 cdef struct CRCPBasic:
     rcp_const_basic m
-
-cdef extern from 'symengine/cwrapper.h':
-    ctypedef CRCPBasic basic[1]

--- a/symengine/lib/symengine.pxd
+++ b/symengine/lib/symengine.pxd
@@ -7,6 +7,10 @@ from libcpp.pair cimport pair
 
 include "config.pxi"
 
+cdef extern from 'symengine/cwrapper.h':
+    ctypedef struct basic_struct:
+        pass
+
 cdef extern from 'symengine/mp_class.h' namespace "SymEngine":
     ctypedef unsigned long mp_limb_t
     ctypedef struct __mpz_struct:

--- a/symengine/lib/symengine.pxd
+++ b/symengine/lib/symengine.pxd
@@ -7,11 +7,6 @@ from libcpp.pair cimport pair
 
 include "config.pxi"
 
-cdef extern from 'symengine/cwrapper.h':
-    ctypedef struct CRCPBasic:
-        rcp_const_basic m
-    ctypedef CRCPBasic basic[1]
-
 cdef extern from 'symengine/mp_class.h' namespace "SymEngine":
     ctypedef unsigned long mp_limb_t
     ctypedef struct __mpz_struct:
@@ -1069,3 +1064,8 @@ cdef extern from "<symengine/solve.h>" namespace "SymEngine":
 cdef extern from "<symengine/printers.h>" namespace "SymEngine":
     string ccode(const Basic &x) nogil except +
     string latex(const Basic &x) nogil except +
+
+cdef extern from 'symengine/cwrapper.h':
+    ctypedef struct CRCPBasic:
+        rcp_const_basic m
+    ctypedef CRCPBasic basic[1]

--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -43,7 +43,7 @@ cpdef object capsule_to_basic(object capsule):
     cdef CRCPBasic *p = <CRCPBasic*>PyCapsule_GetPointer(capsule, NULL)
     return c2py(p.m)
 
-cpdef void basic_to_capsule(object capsule, object basic):
+cpdef void assign_to_capsule(object capsule, object basic):
     cdef CRCPBasic *p_cap = <CRCPBasic*>PyCapsule_GetPointer(capsule, NULL)
     cdef Basic v = sympify(basic)
     p_cap.m = v.thisptr

--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -39,14 +39,14 @@ include "config.pxi"
 class SympifyError(Exception):
     pass
 
-cpdef object sympify_pycapsule(object cap):
-    cdef CRCPBasic *p = <CRCPBasic*>PyCapsule_GetPointer(cap, NULL)
+cpdef object capsule_to_basic(object capsule):
+    cdef CRCPBasic *p = <CRCPBasic*>PyCapsule_GetPointer(capsule, NULL)
     return c2py(p.m)
 
-cpdef void assign_to_pycapsule(object x, object value):
-    cdef CRCPBasic *p_x = <CRCPBasic*>PyCapsule_GetPointer(x, NULL)
-    cdef Basic v = sympify(value)
-    p_x.m = v.thisptr
+cpdef void basic_to_capsule(object capsule, object basic):
+    cdef CRCPBasic *p_cap = <CRCPBasic*>PyCapsule_GetPointer(capsule, NULL)
+    cdef Basic v = sympify(basic)
+    p_cap.m = v.thisptr
 
 cdef object c2py(rcp_const_basic o):
     cdef Basic r

--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -3,7 +3,7 @@ cimport symengine
 from symengine cimport (RCP, pair, map_basic_basic, umap_int_basic,
     umap_int_basic_iterator, umap_basic_num, umap_basic_num_iterator,
     rcp_const_basic, std_pair_short_rcp_const_basic,
-    rcp_const_seriescoeffinterface, CRCPBasic, basic)
+    rcp_const_seriescoeffinterface, CRCPBasic)
 from libcpp cimport bool as cppbool
 from libcpp.string cimport string
 from libcpp.vector cimport vector
@@ -20,6 +20,7 @@ import warnings
 from symengine.compatibility import is_sequence
 import os
 import sys
+from cpython.pycapsule cimport PyCapsule_GetPointer
 
 if sys.version_info[0] == 2:
     from collections import MutableMapping
@@ -38,11 +39,8 @@ include "config.pxi"
 class SympifyError(Exception):
     pass
 
-from cpython.pycapsule cimport PyCapsule_GetPointer
-
 cpdef object sympify_pycapsule(object cap):
-    cdef CRCPBasic *p
-    p = <CRCPBasic*>PyCapsule_GetPointer(cap, NULL)
+    cdef CRCPBasic *p = <CRCPBasic*>PyCapsule_GetPointer(cap, NULL)
     return c2py(p.m)
 
 cpdef void assign_to_pycapsule(object x, object value):

--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -41,7 +41,8 @@ class SympifyError(Exception):
 from cpython.pycapsule cimport PyCapsule_GetPointer
 
 cpdef object sympify_pycapsule(object cap):
-    void *p = PyCapsule_GetPointer(cap, NULL)
+    cdef void *p
+    p = PyCapsule_GetPointer(cap, NULL)
     return c2py(<rcp_const_basic>p)
 
 cdef object c2py(rcp_const_basic o):

--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -46,11 +46,9 @@ cpdef object sympify_pycapsule(object cap):
     return c2py(p.m)
 
 cpdef void assign_to_pycapsule(object x, object value):
-    cdef CRCPBasic *p_x
-    cdef rcp_const_basic v
-    p_x = <CRCPBasic*>PyCapsule_GetPointer(x, NULL)
-    v = sympify(value).thisptr
-    p_x.m = v
+    cdef CRCPBasic *p_x = <CRCPBasic*>PyCapsule_GetPointer(x, NULL)
+    cdef Basic v = sympify(value)
+    p_x.m = v.thisptr
 
 cdef object c2py(rcp_const_basic o):
     cdef Basic r

--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -40,7 +40,7 @@ class SympifyError(Exception):
 
 from cpython.pycapsule cimport PyCapsule_GetPointer
 
-def sympify_pycapsule(cap):
+cpdef object sympify_pycapsule(object cap):
     void *p = PyCapsule_GetPointer(cap, NULL)
     return c2py(<rcp_const_basic>p)
 

--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -45,6 +45,11 @@ cpdef object sympify_pycapsule(object cap):
     p = <CRCPBasic*>PyCapsule_GetPointer(cap, NULL)
     return c2py(p.m)
 
+cpdef void assign_to_pycapsule(object x, object value):
+    cdef CRCPBasic *p_x
+    p_x = <CRCPBasic*>PyCapsule_GetPointer(cap, NULL)
+    p_x.m = sympify(value).thisptr
+
 cdef object c2py(rcp_const_basic o):
     cdef Basic r
     if (symengine.is_a_Add(deref(o))):

--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -3,7 +3,7 @@ cimport symengine
 from symengine cimport (RCP, pair, map_basic_basic, umap_int_basic,
     umap_int_basic_iterator, umap_basic_num, umap_basic_num_iterator,
     rcp_const_basic, std_pair_short_rcp_const_basic,
-    rcp_const_seriescoeffinterface)
+    rcp_const_seriescoeffinterface, basic_struct)
 from libcpp cimport bool as cppbool
 from libcpp.string cimport string
 from libcpp.vector cimport vector
@@ -41,8 +41,8 @@ class SympifyError(Exception):
 from cpython.pycapsule cimport PyCapsule_GetPointer
 
 cpdef object sympify_pycapsule(object cap):
-    cdef void *p
-    p = PyCapsule_GetPointer(cap, NULL)
+    cdef basic_struct *p
+    p = <basic_struct*>PyCapsule_GetPointer(cap, NULL)
     return c2py(<rcp_const_basic>p)
 
 cdef object c2py(rcp_const_basic o):

--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -38,6 +38,12 @@ include "config.pxi"
 class SympifyError(Exception):
     pass
 
+from cpython.pycapsule cimport PyCapsule_GetPointer
+
+def sympify_pycapsule(cap):
+    void *p = PyCapsule_GetPointer(cap, NULL)
+    return c2py(<rcp_const_basic>p)
+
 cdef object c2py(rcp_const_basic o):
     cdef Basic r
     if (symengine.is_a_Add(deref(o))):

--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -3,7 +3,7 @@ cimport symengine
 from symengine cimport (RCP, pair, map_basic_basic, umap_int_basic,
     umap_int_basic_iterator, umap_basic_num, umap_basic_num_iterator,
     rcp_const_basic, std_pair_short_rcp_const_basic,
-    rcp_const_seriescoeffinterface, basic_struct)
+    rcp_const_seriescoeffinterface, CRCPBasic, basic)
 from libcpp cimport bool as cppbool
 from libcpp.string cimport string
 from libcpp.vector cimport vector
@@ -41,9 +41,9 @@ class SympifyError(Exception):
 from cpython.pycapsule cimport PyCapsule_GetPointer
 
 cpdef object sympify_pycapsule(object cap):
-    cdef basic_struct *p
-    p = <basic_struct*>PyCapsule_GetPointer(cap, NULL)
-    return c2py(<rcp_const_basic>p)
+    cdef CRCPBasic *p
+    p = <CRCPBasic*>PyCapsule_GetPointer(cap, NULL)
+    return c2py(p.m)
 
 cdef object c2py(rcp_const_basic o):
     cdef Basic r

--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -47,7 +47,7 @@ cpdef object sympify_pycapsule(object cap):
 
 cpdef void assign_to_pycapsule(object x, object value):
     cdef CRCPBasic *p_x
-    p_x = <CRCPBasic*>PyCapsule_GetPointer(cap, NULL)
+    p_x = <CRCPBasic*>PyCapsule_GetPointer(x, NULL)
     p_x.m = sympify(value).thisptr
 
 cdef object c2py(rcp_const_basic o):

--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -43,9 +43,9 @@ cpdef object capsule_to_basic(object capsule):
     cdef CRCPBasic *p = <CRCPBasic*>PyCapsule_GetPointer(capsule, NULL)
     return c2py(p.m)
 
-cpdef void assign_to_capsule(object capsule, object basic):
+cpdef void assign_to_capsule(object capsule, object value):
     cdef CRCPBasic *p_cap = <CRCPBasic*>PyCapsule_GetPointer(capsule, NULL)
-    cdef Basic v = sympify(basic)
+    cdef Basic v = sympify(value)
     p_cap.m = v.thisptr
 
 cdef object c2py(rcp_const_basic o):

--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -47,8 +47,10 @@ cpdef object sympify_pycapsule(object cap):
 
 cpdef void assign_to_pycapsule(object x, object value):
     cdef CRCPBasic *p_x
+    cdef rcp_const_basic v
     p_x = <CRCPBasic*>PyCapsule_GetPointer(x, NULL)
-    p_x.m = sympify(value).thisptr
+    v = sympify(value).thisptr
+    p_x.m = v
 
 cdef object c2py(rcp_const_basic o):
     cdef Basic r


### PR DESCRIPTION
Added two functions - `sympify_pycapsule` and `assign_to_pycapsule` (maybe there are better names?)

This allows me to pass a symengine object from R to python through PyCapsule and vice versa. Then I can use SymPy functions within R via symengine.py's compatibility layer.