### PR TITLE
Add support for 32 and 16 bit numpy floats

### DIFF
--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -295,9 +295,7 @@ def sympy2symengine(a, raise_error=False):
                 return RealDouble(float(str(a)))
         ELSE:
             return RealDouble(float(str(a)))
-    elif isinstance(a, np.float16):
-        return RealDouble(a)
-    elif isinstance(a, np.float32):
+    elif have_numpy and isinstance(a, (np.float16, np.float32)):
         return RealDouble(a)
     elif a is sympy.I:
         return I
@@ -562,9 +560,7 @@ def _sympify(a, raise_error=True):
         return Integer(a)
     elif isinstance(a, float):
         return RealDouble(a)
-    elif isinstance(a, np.float16):
-        return RealDouble(a)
-    elif isinstance(a, np.float32):
+    elif have_numpy and isinstance(a, (np.float16, np.float32)):
         return RealDouble(a)
     elif isinstance(a, complex):
         return ComplexDouble(a)

--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -295,6 +295,10 @@ def sympy2symengine(a, raise_error=False):
                 return RealDouble(float(str(a)))
         ELSE:
             return RealDouble(float(str(a)))
+    elif isinstance(a, np.float16):
+        return RealDouble(a)
+    elif isinstance(a, np.float32):
+        return RealDouble(a)
     elif a is sympy.I:
         return I
     elif a is sympy.E:
@@ -557,6 +561,10 @@ def _sympify(a, raise_error=True):
     elif isinstance(a, numbers.Integral):
         return Integer(a)
     elif isinstance(a, float):
+        return RealDouble(a)
+    elif isinstance(a, np.float16):
+        return RealDouble(a)
+    elif isinstance(a, np.float32):
         return RealDouble(a)
     elif isinstance(a, complex):
         return ComplexDouble(a)

--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -295,8 +295,6 @@ def sympy2symengine(a, raise_error=False):
                 return RealDouble(float(str(a)))
         ELSE:
             return RealDouble(float(str(a)))
-    elif have_numpy and isinstance(a, (np.float16, np.float32)):
-        return RealDouble(a)
     elif a is sympy.I:
         return I
     elif a is sympy.E:

--- a/symengine/tests/test_subs.py
+++ b/symengine/tests/test_subs.py
@@ -1,7 +1,7 @@
-import numpy as np
+import unittest
 
 from symengine.utilities import raises
-from symengine import Symbol, sin, cos, sqrt, Add, function_symbol
+from symengine import Symbol, sin, cos, sqrt, Add, function_symbol, have_numpy
 
 
 def test_basic():
@@ -60,13 +60,17 @@ def test_xreplace():
     assert f.xreplace({x: y}) == sin(cos(y))
 
 
+@unittest.skipUnless(have_numpy, "Numpy not installed")
 def test_float32():
+    import numpy as np
     x = Symbol("x")
     expr = x * 2
     assert expr.subs({x: np.float32(2)}) == 4.0
 
 
+@unittest.skipUnless(have_numpy, "Numpy not installed")
 def test_float16():
+    import numpy as np
     x = Symbol("x")
     expr = x * 2
     assert expr.subs({x: np.float16(2)}) == 4.0

--- a/symengine/tests/test_subs.py
+++ b/symengine/tests/test_subs.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from symengine.utilities import raises
 from symengine import Symbol, sin, cos, sqrt, Add, function_symbol
 
@@ -56,3 +58,15 @@ def test_xreplace():
     y = Symbol("y")
     f = sin(cos(x))
     assert f.xreplace({x: y}) == sin(cos(y))
+
+
+def test_float32():
+    x = Symbol("x")
+    expr = x * 2
+    assert expr.subs({x: np.float32(2)}) == 4.0
+
+
+def test_float16():
+    x = Symbol("x")
+    expr = x * 2
+    assert expr.subs({x: np.float16(2)}) == 4.0


### PR DESCRIPTION
This commit adds support for 32 and 16 bit floats numpy as input types.
Since it doesn't look like there is a native symengine type for working
with single (or half) precision floats outside of using MPFR (which
seemed like the wrong approach here, it might make sense for np.float128
in a follow up though) this implicitly casts the np.float16 and
np.float32 types to doubles and just behaves as float/np.float64.

Fixes #351