### PR TITLE
Evaluate Relationals when casting to bool

### DIFF
--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -1502,6 +1502,14 @@ class Relational(Boolean):
     def is_Relational(self):
         return True
 
+    def __bool__(self):
+        if len(self.free_symbols):
+            # If there are any free symbols, then boolean evaluation is ambiguous in most cases. Throw a Type Error
+            raise TypeError(f'Relational with free symbols cannot be cast as bool: {self}')
+        else:
+            simplification = self.simplify()
+            return bool(simplification)
+
 Rel = Relational
 
 

--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -1504,20 +1504,16 @@ class Relational(Boolean):
 
     def __bool__(self):
         # We will narrow down the boolean value of our relational with some simple checks
-        lhs, rhs = self.args
-
-        # Two expressions are equal if their difference is equal to 0.
+        # Get the Left- and Right-hand-sides of the relation, since two expressions are equal if their difference
+        # is equal to 0.
         # If the expand method will not cancel out free symbols in the given expression, then this
         # will throw a TypeError.
+        lhs, rhs = self.args
         difference = (lhs - rhs).expand().evalf()
-        float_threshold = 1e-9  # Maximum difference we will allow before doing the full simplification
 
         if len(difference.free_symbols):
             # If there are any free symbols, then boolean evaluation is ambiguous in most cases. Throw a Type Error
             raise TypeError(f'Relational with free symbols cannot be cast as bool: {self}')
-        elif difference > float_threshold:
-            # If the float evaluation is larger than the threshold, we can skip the full simplification.
-            return False
         else:
             # If the float evaluation is smaller than the threshold, then we will need a full simplification.
             return bool(self.simplify())
@@ -1543,6 +1539,29 @@ class Equality(Relational):
     @property
     def is_Equality(self):
         return True
+
+    def __bool__(self):
+        # We override __bool__ in Equality just for some an additional check (for speed)
+        # that does not easily generalize to other relationals.
+        #
+        # We will narrow down the boolean value of our relational with some simple checks
+        # Get the Left- and Right-hand-sides of the relation, since two expressions are equal if their difference
+        # is equal to 0.
+        # If the expand method will not cancel out free symbols in the given expression, then this
+        # will throw a TypeError.
+        lhs, rhs = self.args
+        difference = (lhs - rhs).expand().evalf()
+        float_threshold = 1e-9  # Maximum difference we will allow before doing the full simplification
+
+        if len(difference.free_symbols):
+            # If there are any free symbols, then boolean evaluation is ambiguous in most cases. Throw a Type Error
+            raise TypeError(f'Relational with free symbols cannot be cast as bool: {self}')
+        elif difference > float_threshold:
+            # If the float evaluation is larger than the threshold, we can skip the full simplification.
+            return False
+        else:
+            # If the float evaluation is smaller than the threshold, then we will need a full simplification.
+            return bool(self.simplify())
 
     func = __class__
 

--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -1516,7 +1516,13 @@ class Relational(Boolean):
             raise TypeError(f'Relational with free symbols cannot be cast as bool: {self}')
         else:
             # If the float evaluation is smaller than the threshold, then we will need a full simplification.
-            return bool(self.simplify())
+            # If sympy is not present, then we can do a workaround with evalf. This work around is not as precise as
+            # using sympy's simplification.
+            try:
+                return bool(self.simplify())
+            except ImportError:
+                relational_type = type(self)
+                return bool(relational_type(difference, 0).evalf())
 
 Rel = Relational
 
@@ -1556,12 +1562,17 @@ class Equality(Relational):
         if len(difference.free_symbols):
             # If there are any free symbols, then boolean evaluation is ambiguous in most cases. Throw a Type Error
             raise TypeError(f'Relational with free symbols cannot be cast as bool: {self}')
-        elif difference > float_threshold:
+        elif abs(difference) > float_threshold:
             # If the float evaluation is larger than the threshold, we can skip the full simplification.
             return False
         else:
             # If the float evaluation is smaller than the threshold, then we will need a full simplification.
-            return bool(self.simplify())
+            # If sympy is not present, then we can do a workaround with evalf. This work around is not as precise as
+            # using sympy's simplification.
+            try:
+                return bool(self.simplify())
+            except ImportError:
+                return bool(Eq(difference, 0).evalf())
 
     func = __class__
 

--- a/symengine/tests/CMakeLists.txt
+++ b/symengine/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ install(FILES __init__.py
     test_matrices.py
     test_ntheory.py
     test_printing.py
+    test_relationals.py
     test_sage.py
     test_series_expansion.py
     test_sets.py

--- a/symengine/tests/test_eval.py
+++ b/symengine/tests/test_eval.py
@@ -16,7 +16,7 @@ def test_eval_double2():
     x = Symbol("x")
     e = sin(x)**2 + sqrt(2)
     raises(RuntimeError, lambda: e.n(real=True))
-    assert abs(e.n() - x**2 - 1.414) < 1e-3
+    assert abs(e.n() - sin(x)**2.0 - 1.414) < 1e-3
 
 def test_n():
     x = Symbol("x")

--- a/symengine/tests/test_relationals.py
+++ b/symengine/tests/test_relationals.py
@@ -1,0 +1,45 @@
+from symengine.utilities import raises
+from symengine import (Symbol, sympify, Eq)
+
+
+def test_equals_constants():
+    assert bool(Eq(3, 3))
+    assert bool(Eq(4, 2**2))
+
+    # Short and long are symbolically equivalent, but sufficiently different in form that expand() and evalf() does not
+    # catch it. Despite the float evaluation differing ever so slightly, ideally, our equality should still catch
+    # symbolically equal expressions.
+    short = sympify('(3/2)*sqrt(11 + sqrt(21))')
+    long = sympify('sqrt((33/8 + (1/24)*sqrt(27)*sqrt(63))**2 + ((3/8)*sqrt(27) + (-1/8)*sqrt(63))**2)')
+    assert bool(Eq(short, short))
+    assert bool(Eq(long, long))
+    assert bool(Eq(short, long))
+
+
+def test_not_equals_constants():
+    assert not bool(Eq(3, 4))
+    assert not bool(Eq(4, 4-.000000001))
+
+
+def test_equals_symbols():
+    x = Symbol("x")
+    y = Symbol("y")
+    assert bool(Eq(x, x))
+    assert bool(Eq(x**2, x*x))
+    assert bool(Eq(x*y, y*x))
+
+
+def test_not_equals_symbols():
+    x = Symbol("x")
+    y = Symbol("y")
+    assert not bool(Eq(x, x+1))
+    assert not bool(Eq(x**2, x**2+1))
+    assert not bool(Eq(x * y, y * x+1))
+
+
+def test_not_equals_symbols_raise_typeerror():
+    x = Symbol("x")
+    y = Symbol("y")
+    raises(TypeError, lambda: bool(Eq(x, 1)))
+    raises(TypeError, lambda: bool(Eq(x, y)))
+    raises(TypeError, lambda: bool(Eq(x**2, x)))

--- a/symengine/tests/test_relationals.py
+++ b/symengine/tests/test_relationals.py
@@ -1,40 +1,70 @@
 from symengine.utilities import raises
-from symengine import (Symbol, sympify, Eq)
+from symengine import (Symbol, sympify, Eq, Ne, Lt, Le, Ge, Gt, sqrt, pi)
+
+
+def assert_equal(x, y):
+    """Asserts that x and y are equal. This will test Equality, Unequality, LE, and GE classes."""
+    assert bool(Eq(x, y))
+    assert not bool(Ne(x, y))
+    assert bool(Ge(x, y))
+    assert bool(Le(x, y))
+
+
+def assert_not_equal(x, y):
+    """Asserts that x and y are not equal. This will test Equality and Unequality"""
+    assert not bool(Eq(x, y))
+    assert bool(Ne(x, y))
+
+
+def assert_less_than(x, y):
+    """Asserts that x is less than y. This will test Le, Lt, Ge, Gt classes."""
+    assert bool(Le(x, y))
+    assert bool(Lt(x, y))
+    assert not bool(Ge(x, y))
+    assert not bool(Gt(x, y))
+
+
+def assert_greater_than(x, y):
+    """Asserts that x is greater than y. This will test Le, Lt, Ge, Gt classes."""
+    assert not bool(Le(x, y))
+    assert not bool(Lt(x, y))
+    assert bool(Ge(x, y))
+    assert bool(Gt(x, y))
 
 
 def test_equals_constants():
-    assert bool(Eq(3, 3))
-    assert bool(Eq(4, 2**2))
+    assert_equal(3, 3)
+    assert_equal(4, 2 ** 2)
 
     # Short and long are symbolically equivalent, but sufficiently different in form that expand() and evalf() does not
     # catch it. Despite the float evaluation differing ever so slightly, ideally, our equality should still catch
     # symbolically equal expressions.
     short = sympify('(3/2)*sqrt(11 + sqrt(21))')
     long = sympify('sqrt((33/8 + (1/24)*sqrt(27)*sqrt(63))**2 + ((3/8)*sqrt(27) + (-1/8)*sqrt(63))**2)')
-    assert bool(Eq(short, short))
-    assert bool(Eq(long, long))
-    assert bool(Eq(short, long))
+    assert_equal(short, short)
+    assert_equal(long, long)
+    assert_equal(short, long)
 
 
 def test_not_equals_constants():
-    assert not bool(Eq(3, 4))
-    assert not bool(Eq(4, 4-.000000001))
+    assert_not_equal(3, 4)
+    assert_not_equal(4, 4 - .000000001)
 
 
 def test_equals_symbols():
     x = Symbol("x")
     y = Symbol("y")
-    assert bool(Eq(x, x))
-    assert bool(Eq(x**2, x*x))
-    assert bool(Eq(x*y, y*x))
+    assert_equal(x, x)
+    assert_equal(x ** 2, x * x)
+    assert_equal(x * y, y * x)
 
 
 def test_not_equals_symbols():
     x = Symbol("x")
     y = Symbol("y")
-    assert not bool(Eq(x, x+1))
-    assert not bool(Eq(x**2, x**2+1))
-    assert not bool(Eq(x * y, y * x+1))
+    assert_not_equal(x, x + 1)
+    assert_not_equal(x ** 2, x ** 2 + 1)
+    assert_not_equal(x * y, y * x + 1)
 
 
 def test_not_equals_symbols_raise_typeerror():
@@ -42,4 +72,34 @@ def test_not_equals_symbols_raise_typeerror():
     y = Symbol("y")
     raises(TypeError, lambda: bool(Eq(x, 1)))
     raises(TypeError, lambda: bool(Eq(x, y)))
-    raises(TypeError, lambda: bool(Eq(x**2, x)))
+    raises(TypeError, lambda: bool(Eq(x ** 2, x)))
+
+
+def test_less_than_constants():
+    assert_less_than(1, 2)
+    assert_less_than(sqrt(2), 2)
+    assert_less_than(-1, 1)
+    assert_less_than(3.14, pi)
+
+
+def test_greater_than_constants():
+    assert_greater_than(2, 1)
+    assert_greater_than(2, sqrt(2))
+    assert_greater_than(1, -1, )
+    assert_greater_than(pi, 3.14)
+
+
+def test_less_than_raises_typeerror():
+    x = Symbol("x")
+    y = Symbol("y")
+    raises(TypeError, lambda: bool(Lt(x, 1)))
+    raises(TypeError, lambda: bool(Lt(x, y)))
+    raises(TypeError, lambda: bool(Lt(x ** 2, x)))
+
+
+def test_greater_than_raises_typeerror():
+    x = Symbol("x")
+    y = Symbol("y")
+    raises(TypeError, lambda: bool(Gt(x, 1)))
+    raises(TypeError, lambda: bool(Gt(x, y)))
+    raises(TypeError, lambda: bool(Gt(x ** 2, x)))


### PR DESCRIPTION
#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
Fixes #312. Before, a Relational operator would always evaluate to True when cast as a bool, regardless of whether or not its left and right hand sides were actually equal. This fixes that. Additionally, if the evaluation is ambiguous (namely, there are free variables), it throws a TypeError. 


#### Brief description of what is fixed or changed
This modifies the class definition of Relational in the symengine python wrapper by overriding __bool__. If the relation can sucessfully and unambiguously evaluated as a bool (i.e. both sides are constants with no free variables), then it does the simplification using its simplify function.

If the relational's boolean value is ambiguous (i.e. it has free symbols), then it throws the `TypeError(f'Relational with free symbols cannot be cast as bool: {self}')`.

This is closer to the expected behavior of the bool function on these types.


#### Other comments
The TypeError check will subtract one side from the other, and then expand out the expression. If that expansion has no free symbols, then the expression will evaluate normally.
