### PR TITLE
Fix leading underscore in converted dummy name by slicing

### DIFF
--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -1262,7 +1262,7 @@ cdef class Dummy(Symbol):
 
     def _sympy_(self):
         import sympy
-        return sympy.Dummy(str(self))
+        return sympy.Dummy(str(self)[1:])
 
     @property
     def is_Dummy(self):


### PR DESCRIPTION
**Possible fix for #372 (leading underscore appearing in converted dummy type)**
Modified line 1265 from:
`return sympy.Dummy(str(self)) `
to
`return sympy.Dummy(str(self)[1:]` 