### PR TITLE
Faster rational creation

### DIFF
--- a/symengine/lib/symengine.pxd
+++ b/symengine/lib/symengine.pxd
@@ -379,6 +379,7 @@ cdef extern from "<symengine/integer.h>" namespace "SymEngine":
         Integer(integer_class i) nogil
         int compare(const Basic &o) nogil
         integer_class as_integer_class() nogil
+        RCP[Number] divint(const Integer &other) nogil
     cdef long mp_get_si(integer_class &i) nogil
     cdef double mp_get_d(integer_class &i) nogil
     cdef RCP[const Integer] integer(int i) nogil
@@ -390,6 +391,8 @@ cdef extern from "<symengine/integer.h>" namespace "SymEngine":
 cdef extern from "<symengine/rational.h>" namespace "SymEngine":
     cdef cppclass Rational(Number):
         rational_class as_rational_class() nogil
+        @staticmethod
+        RCP[const Number] from_two_ints(const long n, const long d) nogil
     cdef double mp_get_d(rational_class &i) nogil
     cdef RCP[const Number] from_mpq "SymEngine::Rational::from_mpq"(rational_class r) nogil
     cdef void get_num_den(const Rational &rat, const Ptr[RCP[Integer]] &num,

--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -1664,7 +1664,25 @@ cdef class Number(Expr):
 class Rational(Number):
 
     def __new__(cls, p, q):
-        return Integer(p)/q
+        p = int(p)
+        q = int(q)
+        cdef int p_
+        cdef int q_
+        cdef symengine.integer_class p__
+        cdef symengine.integer_class q__
+        cdef string tmp
+        try:
+            # Try to convert p and q to int
+            p_ = p
+            q_ = q
+            return c2py(<rcp_const_basic>symengine.Rational.from_two_ints(p_, q_));
+        except OverflowError:
+            # Too big, need to use mpz
+            tmp = str(p).encode("utf-8")
+            p__ = symengine.integer_class(tmp)
+            tmp = str(q).encode("utf-8")
+            q__ = symengine.integer_class(tmp)
+            return c2py(<rcp_const_basic>symengine.Integer(p__).divint(symengine.Integer(q__)))
 
     @property
     def is_Rational(self):


### PR DESCRIPTION
Optimization of the creation of `Rational`. Partially addressing #390.

Benchmarked using 

```python
In [1]: %%timeit a=random.randint(1, 1e6); b=random.randint(1,1e6)
   ...:          symengine.Rational(a, b)

In [2]: %%timeit a=random.randint(1, 1e12); b=random.randint(1,1e12)
   ...:          symengine.Rational(a, b)
```

For smaller numbers I got 2800 ns before this PR and 660ns after. For larger numbers I got 4230ns before this PR and 1710 after. (sympy need 240 ns for both examples)