### PR TITLE
Use print() function in both Python 2 and 3

### DIFF
--- a/benchmarks/expand2_sage.py
+++ b/benchmarks/expand2_sage.py
@@ -1,9 +1,10 @@
+from __future__ import print_function
 from timeit import default_timer as clock
 from sage.all import var
 var("x y z w")
 e = (x+y+z+w)**15
 f = e*(e+w)
-print f
+print(f)
 t1 = clock()
 g = f.expand()
 t2 = clock()

--- a/benchmarks/expand3.py
+++ b/benchmarks/expand3.py
@@ -1,10 +1,11 @@
+from __future__ import print_function
 import sys
 sys.path.append("..")
 from timeit import default_timer as clock
 from symengine import var
 var("x y z")
 f = (x**y + y**z + z**x)**100
-print f
+print(f)
 t1 = clock()
 g = f.expand()
 t2 = clock()

--- a/benchmarks/expand3_sage.py
+++ b/benchmarks/expand3_sage.py
@@ -1,9 +1,10 @@
+from __future__ import print_function
 from timeit import default_timer as clock
 from sage.all import var
 var("x y z")
 f = (x**y + y**z + z**x)**100
-print f
+print(f)
 t1 = clock()
 g = f.expand()
 t2 = clock()
-print "Total time:", t2-t1, "s"
+print("Total time:", t2-t1, "s")

--- a/benchmarks/expand4_sage.py
+++ b/benchmarks/expand4_sage.py
@@ -1,12 +1,13 @@
-print "import..."
+from __future__ import print_function
+print("import...")
 from timeit import default_timer as clock
 from sage.all import var
 var("x")
 e = 1
-print "constructing expression..."
+print("constructing expression...")
 for i in range(1, 351):
     e *= (i+x)**3
-print "running benchmark..."
+print("running benchmark...")
 t1 = clock()
 f = e.expand()
 t2 = clock()

--- a/benchmarks/expand5.py
+++ b/benchmarks/expand5.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys
 sys.path.append("..")
 from timeit import default_timer as clock
@@ -5,7 +6,7 @@ from symengine import var
 var("x y z")
 e = (x+y+z+1)**15
 f = e*(e+1)
-print f
+print(f)
 t1 = clock()
 g = f.expand()
 t2 = clock()

--- a/benchmarks/expand5_sage.py
+++ b/benchmarks/expand5_sage.py
@@ -1,10 +1,11 @@
+from __future__ import print_function
 from timeit import default_timer as clock
 from sage.all import var
 var("x y z")
 e = (x+y+z+1)**15
 f = e*(e+1)
-print f
+print(f)
 t1 = clock()
 g = f.expand()
 t2 = clock()
-print "Total time:", t2-t1, "s"
+print("Total time:", t2-t1, "s")

--- a/benchmarks/kane.py
+++ b/benchmarks/kane.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys
 sys.path.append("..")
 from timeit import default_timer as clock
@@ -20,7 +21,7 @@ cf = ce.subs(function_symbol("q5", Symbol("t")), Symbol("sq5"))
 t2 = clock()
 print("Total time:", t2-t1, "s")
 
-print "SymPy diff:"
+print("SymPy diff:")
 t1 = clock()
 g = f.diff(sympy.Symbol("sq5"))
 t2 = clock()


### PR DESCRIPTION
Old-style `print` expressions are a **syntax errors** in Python3

`print()` function works as expected on both Python 2 and Python 3.