### PR TITLE
Add boostmp to test matrix, also bump llvm version tested.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,7 @@ jobs:
             WITH_LLVM: 14
             WITH_SCIPY: yes
             INTEGER_CLASS: 'boostmp'
+            PYTEST_ADDOPTS: '-k "not integer_nthroot"'
             OS: ubuntu-22.04
             EXTRA_APT_REPOSITORY: 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-14 main'
             EXTRA_APT_PACKAGES: 'llvm-14'
@@ -144,6 +145,7 @@ jobs:
       run: |
         source bin/test_symengine_unix.sh
       env:
+        PYTEST_ADDOPTS: ${{ matrix.PYTEST_ADDOPTS }}
         USE_GLIBCXX_DEBUG: ${{ matrix.USE_GLIBCXX_DEBUG }}
         WITH_MPFR: ${{ matrix.WITH_MPFR }}
         BUILD_BENCHMARKS: ${{ matrix.BUILD_BENCHMARKS }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,12 +92,12 @@ jobs:
           - BUILD_TYPE: Debug
             PYTHON_VERSION: '3.10'
             WITH_SYMPY: yes
-            WITH_LLVM: 15
+            WITH_LLVM: 14
             WITH_SCIPY: yes
             INTEGER_CLASS: 'boostmp'
             OS: ubuntu-22.04
-            EXTRA_APT_REPOSITORY: 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main'
-            EXTRA_APT_PACKAGES: 'llvm-15'
+            EXTRA_APT_REPOSITORY: 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-14 main'
+            EXTRA_APT_PACKAGES: 'llvm-14'
 
           - BUILD_TYPE: Debug
             PYTHON_VERSION: '3.7'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,13 +90,14 @@ jobs:
             CC: clang
  
           - BUILD_TYPE: Debug
-            PYTHON_VERSION: '3.8'
+            PYTHON_VERSION: '3.10'
             WITH_SYMPY: yes
-            WITH_LLVM: 13 
+            WITH_LLVM: 15
             WITH_SCIPY: yes
-            OS: ubuntu-20.04
-            EXTRA_APT_REPOSITORY: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main'
-            EXTRA_APT_PACKAGES: 'llvm-13'
+            INTEGER_CLASS: 'boostmp'
+            OS: ubuntu-22.04
+            EXTRA_APT_REPOSITORY: 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main'
+            EXTRA_APT_PACKAGES: 'llvm-15'
 
           - BUILD_TYPE: Debug
             PYTHON_VERSION: '3.7'

--- a/symengine/lib/symengine.pxd
+++ b/symengine/lib/symengine.pxd
@@ -350,12 +350,12 @@ cdef extern from "<symengine/number.h>" namespace "SymEngine":
         pass
     cdef cppclass NumberWrapper(Basic):
         pass
-    cdef int is_zero(const Basic &x) nogil
-    cdef int is_positive(const Basic &x) nogil
-    cdef int is_negative(const Basic &x) nogil
-    cdef int is_nonnegative(const Basic &x) nogil
-    cdef int is_nonpositive(const Basic &x) nogil
-    cdef int is_real(const Basic &x) nogil
+    cdef tribool is_zero(const Basic &x) nogil
+    cdef tribool is_positive(const Basic &x) nogil
+    cdef tribool is_negative(const Basic &x) nogil
+    cdef tribool is_nonnegative(const Basic &x) nogil
+    cdef tribool is_nonpositive(const Basic &x) nogil
+    cdef tribool is_real(const Basic &x) nogil
 
 cdef extern from "pywrapper.h" namespace "SymEngine":
     cdef cppclass PyNumber(NumberWrapper):
@@ -829,15 +829,15 @@ cdef extern from "<symengine/matrix.h>" namespace "SymEngine":
         void row_del(unsigned k) nogil
         void col_del(unsigned k) nogil
         rcp_const_basic trace() nogil
-        int is_zero() nogil
-        int is_real() nogil
-        int is_diagonal() nogil
-        int is_symmetric() nogil
-        int is_hermitian() nogil
-        int is_weakly_diagonally_dominant() nogil
-        int is_strictly_diagonally_dominant() nogil
-        int is_positive_definite() nogil
-        int is_negative_definite() nogil
+        tribool is_zero() nogil
+        tribool is_real() nogil
+        tribool is_diagonal() nogil
+        tribool is_symmetric() nogil
+        tribool is_hermitian() nogil
+        tribool is_weakly_diagonally_dominant() nogil
+        tribool is_strictly_diagonally_dominant() nogil
+        tribool is_positive_definite() nogil
+        tribool is_negative_definite() nogil
 
     bool is_a_DenseMatrix "SymEngine::is_a<SymEngine::DenseMatrix>"(const MatrixBase &b) nogil
     DenseMatrix* static_cast_DenseMatrix "static_cast<SymEngine::DenseMatrix*>"(const MatrixBase *a)

--- a/symengine/lib/symengine.pxd
+++ b/symengine/lib/symengine.pxd
@@ -1104,6 +1104,19 @@ cdef extern from "<symengine/solve.h>" namespace "SymEngine":
     cdef RCP[const Set] solve(rcp_const_basic &f, RCP[const Symbol] &sym, RCP[const Set] &domain) nogil except +
     cdef vec_basic linsolve(const vec_basic &eqs, const vec_sym &syms) nogil except +
 
+cdef extern from "symengine/tribool.h" namespace "SymEngine":
+    cdef cppclass tribool:
+        pass  # tribool is an enum class
+
+    cdef bool is_true(tribool) nogil
+    cdef bool is_false(tribool) nogil
+    cdef bool is_indeterminate(tribool) nogil
+
+cdef extern from "symengine/tribool.h" namespace "SymEngine::tribool":
+    cdef tribool indeterminate
+    cdef tribool trifalse
+    cdef tribool tritrue
+
 cdef extern from "<symengine/printers.h>" namespace "SymEngine":
     string ccode(const Basic &x) nogil except +
     string latex(const Basic &x) nogil except +

--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -3,7 +3,7 @@ cimport symengine
 from symengine cimport (RCP, pair, map_basic_basic, umap_int_basic,
     umap_int_basic_iterator, umap_basic_num, umap_basic_num_iterator,
     rcp_const_basic, std_pair_short_rcp_const_basic,
-    rcp_const_seriescoeffinterface, CRCPBasic)
+    rcp_const_seriescoeffinterface, CRCPBasic, tribool)
 from libcpp cimport bool as cppbool
 from libcpp.string cimport string
 from libcpp.vector cimport vector
@@ -3696,39 +3696,39 @@ cdef class DenseMatrixBase(MatrixBase):
 
     @property
     def is_zero_matrix(self):
-        return tribool(deref(symengine.static_cast_DenseMatrix(self.thisptr)).is_zero())
+        return tribool_py(deref(symengine.static_cast_DenseMatrix(self.thisptr)).is_zero())
 
     @property
     def is_real_matrix(self):
-        return tribool(deref(symengine.static_cast_DenseMatrix(self.thisptr)).is_real())
+        return tribool_py(deref(symengine.static_cast_DenseMatrix(self.thisptr)).is_real())
 
     @property
     def is_diagonal(self):
-        return tribool(deref(symengine.static_cast_DenseMatrix(self.thisptr)).is_diagonal())
+        return tribool_py(deref(symengine.static_cast_DenseMatrix(self.thisptr)).is_diagonal())
 
     @property
     def is_symmetric(self):
-        return tribool(deref(symengine.static_cast_DenseMatrix(self.thisptr)).is_symmetric())
+        return tribool_py(deref(symengine.static_cast_DenseMatrix(self.thisptr)).is_symmetric())
 
     @property
     def is_hermitian(self):
-        return tribool(deref(symengine.static_cast_DenseMatrix(self.thisptr)).is_hermitian())
+        return tribool_py(deref(symengine.static_cast_DenseMatrix(self.thisptr)).is_hermitian())
 
     @property
     def is_weakly_diagonally_dominant(self):
-        return tribool(deref(symengine.static_cast_DenseMatrix(self.thisptr)).is_weakly_diagonally_dominant())
+        return tribool_py(deref(symengine.static_cast_DenseMatrix(self.thisptr)).is_weakly_diagonally_dominant())
 
     @property
     def is_strongly_diagonally_dominant(self):
-        return tribool(deref(symengine.static_cast_DenseMatrix(self.thisptr)).is_strictly_diagonally_dominant())
+        return tribool_py(deref(symengine.static_cast_DenseMatrix(self.thisptr)).is_strictly_diagonally_dominant())
 
     @property
     def is_positive_definite(self):
-        return tribool(deref(symengine.static_cast_DenseMatrix(self.thisptr)).is_positive_definite())
+        return tribool_py(deref(symengine.static_cast_DenseMatrix(self.thisptr)).is_positive_definite())
 
     @property
     def is_negative_definite(self):
-        return tribool(deref(symengine.static_cast_DenseMatrix(self.thisptr)).is_negative_definite())
+        return tribool_py(deref(symengine.static_cast_DenseMatrix(self.thisptr)).is_negative_definite())
 
     @property
     def T(self):
@@ -5347,47 +5347,51 @@ def contains(expr, sset):
     return c2py(<rcp_const_basic>(symengine.contains(expr_.thisptr, s)))
 
 
-def tribool(value):
-    if value == -1:
+def tribool_py(tribool value):
+    if is_indeterminate(value):
         return None
+    elif is_true(value):
+        return True
+    elif is_false(value):
+        return False
     else:
-        return bool(value)
+        raise RuntimeError("Internal error in symengine.py, tribool got a fourth value.")
 
 
 def is_zero(expr):
     cdef Basic expr_ = sympify(expr)
     cdef int tbool = symengine.is_zero(deref(expr_.thisptr))
-    return tribool(tbool)
+    return tribool_py(tbool)
 
 
 def is_positive(expr):
     cdef Basic expr_ = sympify(expr)
     cdef int tbool = symengine.is_positive(deref(expr_.thisptr))
-    return tribool(tbool)
+    return tribool_py(tbool)
 
 
 def is_negative(expr):
     cdef Basic expr_ = sympify(expr)
     cdef int tbool = symengine.is_negative(deref(expr_.thisptr))
-    return tribool(tbool)
+    return tribool_py(tbool)
 
 
 def is_nonpositive(expr):
     cdef Basic expr_ = sympify(expr)
     cdef int tbool = symengine.is_nonpositive(deref(expr_.thisptr))
-    return tribool(tbool)
+    return tribool_py(tbool)
 
 
 def is_nonnegative(expr):
     cdef Basic expr_ = sympify(expr)
     cdef int tbool = symengine.is_nonnegative(deref(expr_.thisptr))
-    return tribool(tbool)
+    return tribool_py(tbool)
 
 
 def is_real(expr):
     cdef Basic expr_ = sympify(expr)
     cdef int tbool = symengine.is_real(deref(expr_.thisptr))
-    return tribool(tbool)
+    return tribool_py(tbool)
 
 
 def set_union(*args):

--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -3,7 +3,7 @@ cimport symengine
 from symengine cimport (RCP, pair, map_basic_basic, umap_int_basic,
     umap_int_basic_iterator, umap_basic_num, umap_basic_num_iterator,
     rcp_const_basic, std_pair_short_rcp_const_basic,
-    rcp_const_seriescoeffinterface, CRCPBasic, tribool)
+                        rcp_const_seriescoeffinterface, CRCPBasic, tribool, is_indeterminate, is_true, is_false)
 from libcpp cimport bool as cppbool
 from libcpp.string cimport string
 from libcpp.vector cimport vector
@@ -5347,7 +5347,7 @@ def contains(expr, sset):
     return c2py(<rcp_const_basic>(symengine.contains(expr_.thisptr, s)))
 
 
-def tribool_py(tribool value):
+cdef tribool_py(tribool value):
     if is_indeterminate(value):
         return None
     elif is_true(value):
@@ -5360,37 +5360,37 @@ def tribool_py(tribool value):
 
 def is_zero(expr):
     cdef Basic expr_ = sympify(expr)
-    cdef int tbool = symengine.is_zero(deref(expr_.thisptr))
+    cdef tribool tbool = symengine.is_zero(deref(expr_.thisptr))
     return tribool_py(tbool)
 
 
 def is_positive(expr):
     cdef Basic expr_ = sympify(expr)
-    cdef int tbool = symengine.is_positive(deref(expr_.thisptr))
+    cdef tribool tbool = symengine.is_positive(deref(expr_.thisptr))
     return tribool_py(tbool)
 
 
 def is_negative(expr):
     cdef Basic expr_ = sympify(expr)
-    cdef int tbool = symengine.is_negative(deref(expr_.thisptr))
+    cdef tribool tbool = symengine.is_negative(deref(expr_.thisptr))
     return tribool_py(tbool)
 
 
 def is_nonpositive(expr):
     cdef Basic expr_ = sympify(expr)
-    cdef int tbool = symengine.is_nonpositive(deref(expr_.thisptr))
+    cdef tribool tbool = symengine.is_nonpositive(deref(expr_.thisptr))
     return tribool_py(tbool)
 
 
 def is_nonnegative(expr):
     cdef Basic expr_ = sympify(expr)
-    cdef int tbool = symengine.is_nonnegative(deref(expr_.thisptr))
+    cdef tribool tbool = symengine.is_nonnegative(deref(expr_.thisptr))
     return tribool_py(tbool)
 
 
 def is_real(expr):
     cdef Basic expr_ = sympify(expr)
-    cdef int tbool = symengine.is_real(deref(expr_.thisptr))
+    cdef tribool tbool = symengine.is_real(deref(expr_.thisptr))
     return tribool_py(tbool)
 
 

--- a/symengine_version.txt
+++ b/symengine_version.txt
@@ -1,1 +1,1 @@
-v0.9.0
+fcef5c7d6cc848e3f6c0b9ecc5a22d30e5e98f99


### PR DESCRIPTION
When building symengine with boostmp, I get a test failure in `symengine.py`'s test suite. This is due to integer division in boost's multiprecision library throws, and we never catch the c++ excpetion, leading to the exit of the CPython process. I suspect we need to pass a policy somewhere, but first I want to reproduce the error in our CI run.

TODO:
- [x] fix our use of boost's mulitprecision integer so that it does not throw for division-by-zero.

Stack trace:
<details>
<summary>gdb backtrace</summary>
<pre>
tests/test_ntheory.py::test_divides                                                                      
Thread 1 "python3" received signal SIGABRT, Aborted.                                                     
__pthread_kill_implementation (no_tid=0, signo=6, threadid=140737350246400) at ./nptl/pthread_kill.c:44  
44      ./nptl/pthread_kill.c: No such file or directory.                                                
(gdb) bt                                                                                                 
#0  __pthread_kill_implementation (no_tid=0, signo=6, threadid=140737350246400) at ./nptl/pthread_kill.c:
44                                                                                                       
#1  __pthread_kill_internal (signo=6, threadid=140737350246400) at ./nptl/pthread_kill.c:78              
#2  __GI___pthread_kill (threadid=140737350246400, signo=signo@entry=6) at ./nptl/pthread_kill.c:89      
#3  0x00007ffff7c8d476 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26                    
#4  0x00007ffff7c737f3 in __GI_abort () at ./stdlib/abort.c:79                                           
#5  0x00007ffff41eebbe in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6                                
#6  0x00007ffff41fa24c in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6                                
#7  0x00007ffff41fa2b7 in std::terminate() () from /lib/x86_64-linux-gnu/libstdc++.so.6                  
#8  0x00007ffff41fa518 in __cxa_throw () from /lib/x86_64-linux-gnu/libstdc++.so.6                       
#9  0x00007ffff4c905c4 in boost::throw_exception<std::overflow_error> (e=..., loc=...) at /usr/include/bo
ost/throw_exception.hpp:171                                                                              
#10 0x00007ffff4caa75a in boost::multiprecision::backends::divide_unsigned_helper<boost::multiprecision::
backends::cpp_int_backend<0u, 0u, (boost::multiprecision::cpp_integer_type)1, (boost::multiprecision::cpp
_int_check_type)0, std::allocator<unsigned long long> >, boost::multiprecision::backends::cpp_int_backend
<0u, 0u, (boost::multiprecision::cpp_integer_type)1, (boost::multiprecision::cpp_int_check_type)0, std::a
llocator<unsigned long long> > > (result=0x0, x=..., y=0, r=...) at /usr/include/boost/multiprecision/cpp
_int/divide.hpp:339                                                                                      
#11 0x00007ffff4c9fd3e in boost::multiprecision::backends::divide_unsigned_helper<boost::multiprecision::
backends::cpp_int_backend<0u, 0u, (boost::multiprecision::cpp_integer_type)1, (boost::multiprecision::cpp
_int_check_type)0, std::allocator<unsigned long long> >, boost::multiprecision::backends::cpp_int_backend
<0u, 0u, (boost::multiprecision::cpp_integer_type)1, (boost::multiprecision::cpp_int_check_type)0, std::a
llocator<unsigned long long> >, boost::multiprecision::backends::cpp_int_backend<0u, 0u, (boost::multipre
cision::cpp_integer_type)1, (boost::multiprecision::cpp_int_check_type)0, std::allocator<unsigned long lo
ng> > > (result=0x0, x=..., y=..., r=...) at /usr/include/boost/multiprecision/cpp_int/divide.hpp:73     
#12 0x00007ffff4d7f2c0 in boost::multiprecision::backends::eval_modulus<0u, 0u, (boost::multiprecision::c
pp_integer_type)1, (boost::multiprecision::cpp_int_check_type)0, std::allocator<unsigned long long>, 0u, 
0u, (boost::multiprecision::cpp_integer_type)1, (boost::multiprecision::cpp_int_check_type)0, std::alloca
tor<unsigned long long>, 0u, 0u, (boost::multiprecision::cpp_integer_type)1, (boost::multiprecision::cpp_
int_check_type)0, std::allocator<unsigned long long> > (result=..., a=..., b=...) at /usr/include/boost/m
ultiprecision/cpp_int/divide.hpp:532                                                                     
#13 0x00007ffff4effcf4 in boost::multiprecision::operator%<boost::multiprecision::backends::cpp_int_backe
nd<0u, 0u, (boost::multiprecision::cpp_integer_type)1, (boost::multiprecision::cpp_int_check_type)0, std:
:allocator<unsigned long long> > > (a=..., b=...) at /usr/include/boost/multiprecision/detail/no_et_ops.h
pp:176                                                                                                   
#14 0x00007ffff4f97908 in SymEngine::mp_divisible_p (a=..., b=...) at //symengine-d21cfe1ed57168f2b4e0d5b
e854632814387a3f1/symengine/mp_class.h:993                                                               
#15 0x00007ffff4f88c44 in SymEngine::divides (a=..., b=...) at /symengine-d21cfe1ed57168f2b4e0d5be8546328
14387a3f1/symengine/ntheory.cpp:163                                                                      
#16 0x00007ffff570e5a7 in __pyx_pf_9symengine_3lib_17symengine_wrapper_138divides (__pyx_self=0x0, __pyx_
v_a=0x7ffff78600d0, __pyx_v_b=0x7ffff78600d0) at /opt/symengine.py-74867351ed7ffb2f2e97f5807976b54953c0b7
1d/build/lib.linux-x86_64-cpython-310/symengine/lib/symengine_wrapper.cpp:110638
</pre>
</details>

<details>
<summary>the exception being thrown</summary>
<pre>
#10 0x00007ffff4caa75a in boost::multiprecision::backends::divide_unsigned_helper<boost::multiprecision::backends::cpp_int_backend<0u, 0u, (boost::multiprecision::cpp_integer_type)1, (boost::multiprecision::cpp_int_check_type)0, std::allocator<unsigned long long> >, boost::multiprecision::backends::cpp_int_backend<0u, 0u, (boost::multiprecision::cpp_integer_type)1, (boost::multiprecision::cpp_int_check_type)0, std::allocator<unsigned long long> > > (result=0x0, x=..., y=0, r=...) at /usr/include/boost/multiprecision/cpp_int/divide.hpp:339
339           BOOST_THROW_EXCEPTION(std::overflow_error("Integer Division by zero."))
</pre>
</summary>