### PR TITLE
Change lambdify's default for backend to llvm when available

### DIFF
--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -5235,8 +5235,8 @@ def Lambdify(args, *exprs, cppbool real=True, backend=None, order='C',
 
     """
     if backend is None:
-        IF HAVE_SYMENGINE_LLVM and real:
-            backend_default = 'llvm'
+        IF HAVE_SYMENGINE_LLVM:
+            backend_default = 'llvm' if real else 'lambda'
         ELSE:
             backend_default = 'lambda'
         backend = os.getenv('SYMENGINE_LAMBDIFY_BACKEND', backend_default)

--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -5203,7 +5203,7 @@ def Lambdify(args, *exprs, cppbool real=True, backend=None, order='C',
         Whether datatype is ``double`` (``double complex`` otherwise).
     backend : str
         'llvm' or 'lambda'. When ``None`` the environment variable
-        'SYMENGINE_LAMBDIFY_BACKEND' is used (taken as 'lambda' if unset).
+        'SYMENGINE_LAMBDIFY_BACKEND' is used (taken as 'llvm' if available, otherwise 'lambda').
     order : 'C' or 'F'
         C- or Fortran-contiguous memory layout. Note that this affects
         broadcasting: e.g. a (m, n) matrix taking 3 arguments and given a
@@ -5235,7 +5235,11 @@ def Lambdify(args, *exprs, cppbool real=True, backend=None, order='C',
 
     """
     if backend is None:
-        backend = os.getenv('SYMENGINE_LAMBDIFY_BACKEND', "lambda")
+        IF HAVE_SYMENGINE_LLVM:
+            backend_default = 'llvm'
+        ELSE:
+            backend_default = 'lambda'
+        backend = os.getenv('SYMENGINE_LAMBDIFY_BACKEND', backend_default)
     if backend == "llvm":
         IF HAVE_SYMENGINE_LLVM:
             if dtype == None:

--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -5235,7 +5235,7 @@ def Lambdify(args, *exprs, cppbool real=True, backend=None, order='C',
 
     """
     if backend is None:
-        IF HAVE_SYMENGINE_LLVM:
+        IF HAVE_SYMENGINE_LLVM and real:
             backend_default = 'llvm'
         ELSE:
             backend_default = 'lambda'


### PR DESCRIPTION
Background: I actually thought 'llvm' was our default, so I was surprised when I realized it actually isn't:
https://github.com/sympy/sympy/issues/24673#issuecomment-1426260263

People coming to symengine.py is probably doing so for the performance advantage over SymPy, so I think changing the default is helpful here.

This could perhaps be considered mildly backwards incompatible, but I think the pros outweigh the cons. What do you think?