### PR TITLE
Add a lambdify func. that throws ModuleNotFoundError when numpy missing

### DIFF
--- a/symengine/__init__.py
+++ b/symengine/__init__.py
@@ -56,8 +56,10 @@ if have_numpy:
     def lambdify(args, exprs, **kwargs):
         return Lambdify(args, *exprs, **kwargs)
 else:
-    def lambdify(args, exprs, **kwargs):
-        raise ModuleNotFoundError("Cannot import numpy, which is required for `lambdify` to work")
+    def __getattr__(name):
+        if name == 'lambdify':
+            raise AttributeError("Cannot import numpy, which is required for `lambdify` to work")
+        raise AttributeError
 
 __version__ = "0.9.2"
 

--- a/symengine/__init__.py
+++ b/symengine/__init__.py
@@ -59,7 +59,7 @@ else:
     def __getattr__(name):
         if name == 'lambdify':
             raise AttributeError("Cannot import numpy, which is required for `lambdify` to work")
-        raise AttributeError
+        raise AttributeError(f"module 'symengine' has no attribute '{name}'")
 
 __version__ = "0.9.2"
 

--- a/symengine/__init__.py
+++ b/symengine/__init__.py
@@ -55,7 +55,9 @@ if have_numpy:
 
     def lambdify(args, exprs, **kwargs):
         return Lambdify(args, *exprs, **kwargs)
-
+else:
+    def lambdify(args, exprs, **kwargs):
+        raise ModuleNotFoundError("Cannot import numpy, which is required for `lambdify` to work")
 
 __version__ = "0.9.2"
 


### PR DESCRIPTION
Currently `numpy` is an optional dependency. Which is confusing since we don't define `lambdify`, `Lambdify` and `LambdifyCSE` when it's missing.

This PR aims to reduce the surprise/confusion when that situation arises.

cf. https://github.com/sympy/sympy/issues/24673#issuecomment-1429966055
