### PR TITLE
Tentative fix of .has for FunctionSymbol

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,9 @@ cmake_minimum_required(VERSION 2.8.12)
 if (POLICY CMP0057)
   cmake_policy(SET CMP0057 NEW) # needed for llvm >= 16
 endif ()
+if (POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW)  # allow user to set *_ROOT variables
+endif()
 
 project(python_wrapper)
 

--- a/symengine/__init__.py
+++ b/symengine/__init__.py
@@ -26,7 +26,7 @@ from .lib.symengine_wrapper import (
     Gt, Lt, And, Or, Not, Nand, Nor, Xor, Xnor, perfect_power, integer_nthroot,
     isprime, sqrt_mod, Expr, cse, count_ops, ccode, Piecewise, Contains, Interval, FiniteSet,
     linsolve,
-    FunctionSymbol as AppliedUndef,
+    FunctionSymbol,
     golden_ratio as GoldenRatio,
     catalan as Catalan,
     eulergamma as EulerGamma,
@@ -37,6 +37,7 @@ from .functions import *
 from .printing import init_printing
 
 
+AppliedUndef = FunctionSymbol  # an alias
 EmptySet = wrapper.S.EmptySet
 UniversalSet = wrapper.S.UniversalSet
 Reals = wrapper.S.Reals

--- a/symengine/lib/symengine.pxd
+++ b/symengine/lib/symengine.pxd
@@ -930,7 +930,7 @@ cdef extern from "<symengine/prime_sieve.h>" namespace "SymEngine":
         unsigned next_prime() nogil
 
 cdef extern from "<symengine/visitor.h>" namespace "SymEngine":
-    bool has_symbol(const Basic &b, const Symbol &x) nogil except +
+    bool has_symbol(const Basic &b, const Basic &x) nogil except +
     rcp_const_basic coeff(const Basic &b, const Basic &x, const Basic &n) nogil except +
     set_basic free_symbols(const Basic &b) nogil except +
     set_basic free_symbols(const MatrixBase &b) nogil except +

--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -4846,7 +4846,7 @@ def powermod_list(a, b, m):
 def has_symbol(obj, symbol=None):
     cdef Basic b = _sympify(obj)
     cdef Basic s = _sympify(symbol)
-    require(s, Symbol)
+    require(s, (Symbol, FunctionSymbol))
     if (not symbol):
         return not b.free_symbols.empty()
     else:

--- a/symengine/lib/symengine_wrapper.pyx
+++ b/symengine/lib/symengine_wrapper.pyx
@@ -4850,8 +4850,7 @@ def has_symbol(obj, symbol=None):
     if (not symbol):
         return not b.free_symbols.empty()
     else:
-        return symengine.has_symbol(deref(b.thisptr),
-                deref(symengine.rcp_static_cast_Symbol(s.thisptr)))
+        return symengine.has_symbol(deref(b.thisptr), deref(s.thisptr))
 
 
 cdef class _Lambdify(object):

--- a/symengine/tests/test_functions.py
+++ b/symengine/tests/test_functions.py
@@ -85,6 +85,7 @@ def test_derivative():
     assert s.variables == (x,)
 
     fxy = Function("f")(x, y)
+    assert (1+fxy).has(fxy)
     g = Derivative(Function("f")(x, y), x, 2, y, 1)
     assert g == fxy.diff(x, x, y)
     assert g == fxy.diff(y, 1, x, 2)


### PR DESCRIPTION
Tests pass locally.

During debugging I tried to `from symengine import FunctionSymbol`, I had too look into `__init__.py` to find it was renamed to `AppliedUndef`, so I also changed `__init__.py` to simply add this as an alias instead. Also enabled a newer CMake policy (allows to set SymEngine_ROOT as an environment variable).