### PR TITLE
GitHub Action to pip install symengine on current Python and PyPy

### DIFF
--- a/.github/workflows/pip_install.yml
+++ b/.github/workflows/pip_install.yml
@@ -10,6 +10,7 @@ jobs:
         python-version: ['3.12', 'pypy3.10']  # Other versions above install successfully
     runs-on: ubuntu-latest
     steps:
+      - run: sudo apt-get update && sudo apt-get install -y libgmp-dev
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/pip_install.yml
+++ b/.github/workflows/pip_install.yml
@@ -1,0 +1,16 @@
+name: pip_install
+on: [pull_request, push]
+jobs:
+  pip_install:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]  # [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.9', 'pypy3.10']
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install --upgrade pip setuptools wheel
+      - run: pip install symengine

--- a/.github/workflows/pip_install.yml
+++ b/.github/workflows/pip_install.yml
@@ -6,11 +6,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]  # [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.9', 'pypy3.10']
+        # python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.9', 'pypy3.10']
+        python-version: ['3.12', 'pypy3.10']  # Other versions above install successfully
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install --upgrade pip setuptools wheel
+      - run: pip install --upgrade pip
+      - run: pip install --upgrade Cython setuptools wheel
       - run: pip install symengine


### PR DESCRIPTION
`pip install symengine` ___fails___ on Python 3.12 and PyPy 3.10
* https://github.com/symengine/symengine.py/actions/workflows/pip_install.yml
* #421
---
https://github.com/symengine/symengine.py/blob/810ef475f34388bb63ae366bf6b238762b5c2d62/setup.py#L14
https://packaging.python.org/en/latest/current.html#packaging-tool-recommendations raises a 404 Not Found but https://packaging.python.org works.