### PR TITLE
ci: Add Python 3.13.0b1 to the testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,13 @@ jobs:
         include:
           - BUILD_TYPE: Debug
             WITH_BFD: yes
+            PYTHON_VERSION: '3.13.0b1'
+            TEST_SYMPY: yes
+            OS: ubuntu-24.04
+            CC: gcc
+
+          - BUILD_TYPE: Debug
+            WITH_BFD: yes
             PYTHON_VERSION: '3.12'
             TEST_SYMPY: yes
             OS: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
             WITH_BFD: yes
             PYTHON_VERSION: '3.13.0b1'
             TEST_SYMPY: yes
-            OS: ubuntu-24.04
+            OS: ubuntu-22.04
             CC: gcc
 
           - BUILD_TYPE: Debug


### PR DESCRIPTION
https://www.python.org/downloads/release/python-3130b1/

Like:
* #425 
* #427 
* #451

`conda search python` does not yet include any version of Py3.13.