### PR TITLE
Fix build with spaces

### DIFF
--- a/bin/install_travis.sh
+++ b/bin/install_travis.sh
@@ -2,7 +2,7 @@
 
 # symengine's bin/install_travis.sh will install miniconda
 
-export conda_pkgs="python=${PYTHON_VERSION} pip 'cython>=0.29.24' pytest gmp mpfr"
+export conda_pkgs="python=${PYTHON_VERSION} pip pytest gmp mpfr"
 
 if [[ "${WITH_NUMPY}" != "no" ]]; then
     export conda_pkgs="${conda_pkgs} numpy";
@@ -27,7 +27,7 @@ if [[ "${WITH_SAGE}" == "yes" ]]; then
     export conda_pkgs="${conda_pkgs} sage=8.1";
 fi
 
-conda install -q ${conda_pkgs}
+conda install -q ${conda_pkgs} "cython>=0.29.24"
 
 if [[ "${WITH_SYMPY}" != "no" ]]; then
     pip install sympy;

--- a/cmake/FindPython.cmake
+++ b/cmake/FindPython.cmake
@@ -130,7 +130,7 @@ macro(ADD_PYTHON_LIBRARY name)
         configure_file(${CMAKE_SOURCE_DIR}/cmake/version_script.txt
             ${CMAKE_CURRENT_BINARY_DIR}/version_script_${name}.txt @ONLY)
         set_property(TARGET ${name} APPEND_STRING PROPERTY
-            LINK_FLAGS " -Wl,--version-script=${CMAKE_CURRENT_BINARY_DIR}/version_script_${name}.txt")
+            LINK_FLAGS " \"-Wl,--version-script=${CMAKE_CURRENT_BINARY_DIR}/version_script_${name}.txt\"")
     ELSE()
         add_library(${name} SHARED ${ARGN})
     ENDIF()


### PR DESCRIPTION
Building symenginepy as part of the SymForce build, I get an error currently if I try to build under a source directory with a space in the path:

```
[100%] Linking CXX shared library symengine_wrapper.cpython-38-x86_64-linux-gnu.so
c++: error: test/build/symenginepy-prefix/src/symenginepy-build/build/lib.linux-x86_64-cpython-38/symengine/lib/version_script_symengine_wrapper.txt: No such file or directory
make[5]: *** [symengine/lib/CMakeFiles/symengine_wrapper.dir/build.make:121: symengine/lib/symengine_wrapper.cpython-38-x86_64-linux-gnu.so] Error 1
make[4]: *** [CMakeFiles/Makefile2:132: symengine/lib/CMakeFiles/symengine_wrapper.dir/all] Error 2
make[3]: *** [Makefile:136: all] Error 2
error: error building project
make[2]: *** [CMakeFiles/symenginepy.dir/build.make:86: symenginepy-prefix/src/symenginepy-stamp/symenginepy-build] Error 1
```

This change seems to fix that.  I'm not 100% sure in what scenarios this applies to a standalone build of symengine?  But I figured I'd open a PR and propose this change

Coming from here on the SymForce repo: https://github.com/symforce-org/symforce/pull/414