### PR TITLE
Fix Fedora/RedHat installation location (#474)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8.12...4.0.0)
 
 if (POLICY CMP0057)
   cmake_policy(SET CMP0057 NEW) # needed for llvm >= 16

--- a/cmake/FindPython.cmake
+++ b/cmake/FindPython.cmake
@@ -60,7 +60,7 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
 endif()
 
 execute_process(
-    COMMAND ${PYTHON_BIN} -c "from sysconfig import get_paths; print(get_paths()['purelib'])"
+    COMMAND ${PYTHON_BIN} -c "from sysconfig import get_paths; print(get_paths()['platlib'])"
     OUTPUT_VARIABLE PYTHON_INSTALL_PATH_tmp
 )
 string(STRIP ${PYTHON_INSTALL_PATH_tmp} PYTHON_INSTALL_PATH_tmp)

--- a/setup.py
+++ b/setup.py
@@ -221,6 +221,13 @@ and dependencies of wheels
 
 '''
 
+ext_modules = []
+packages = ['symengine', 'symengine.tests']
+if platform.system() == 'Windows':
+    packages += ['symengine.lib']
+else:
+    ext_modules += [Extension(name='symengine.lib', sources=[])]
+
 setup(name="symengine",
       version="0.14.0",
       description="Python library providing wrappers to SymEngine",
@@ -232,8 +239,8 @@ setup(name="symengine",
       url="https://github.com/symengine/symengine.py",
       python_requires='>=3.9,<4',
       zip_safe=False,
-      ext_modules=[Extension(name='symengine.lib', sources=[])],
-      packages=['symengine', 'symengine.tests'],
+      ext_modules=ext_modules,
+      packages=packages,
       cmdclass = cmdclass,
       classifiers=[
         'License :: OSI Approved :: MIT License',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if use_distutils is not None:
 
 if use_setuptools:
     try:
-        from setuptools import Extension, setup
+        from setuptools import setup
         from setuptools.command.install import install as _install
         from setuptools.command.build_ext import build_ext as _build_ext
     except ImportError:
@@ -36,14 +36,13 @@ if use_setuptools:
             from distutils.command.build import build as _build
 
 if not use_setuptools:
-    from distutils.core import Extension, setup
+    from distutils.core import setup
     from distutils.command.install import install as _install
     from distutils.command.build_ext import build_ext as _build_ext
     from distutils.command.build import build as _build
 
 cmake_opts = [("PYTHON_BIN", sys.executable),
-              ("CMAKE_INSTALL_RPATH_USE_LINK_PATH", "yes"),
-              ("CMAKE_POLICY_VERSION_MINIMUM", "3.5")]
+              ("CMAKE_INSTALL_RPATH_USE_LINK_PATH", "yes")]
 cmake_generator = [None]
 cmake_build_type = ["Release"]
 
@@ -118,7 +117,7 @@ class BuildExtWithCmake(_build_ext):
 
         cmake_cmd = ["cmake", source_dir,
             "-DCMAKE_BUILD_TYPE=" + cmake_build_type[0],
-            "-DSYMENGINE_INSTALL_PY_FILES=OFF",
+            "-DSYMENGINE_INSTALL_PY_FILES=ON",
         ]
         cmake_cmd.extend(process_opts(cmake_opts))
         if not path.exists(path.join(build_dir, "CMakeCache.txt")):
@@ -233,8 +232,7 @@ setup(name="symengine",
       url="https://github.com/symengine/symengine.py",
       python_requires='>=3.9,<4',
       zip_safe=False,
-      ext_modules=[Extension(name='symengine.lib', sources=[])],
-      packages=['symengine', 'symengine.tests'],
+      packages=[],
       cmdclass = cmdclass,
       classifiers=[
         'License :: OSI Approved :: MIT License',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if use_distutils is not None:
 
 if use_setuptools:
     try:
-        from setuptools import setup
+        from setuptools import Extension, setup
         from setuptools.command.install import install as _install
         from setuptools.command.build_ext import build_ext as _build_ext
     except ImportError:
@@ -36,7 +36,7 @@ if use_setuptools:
             from distutils.command.build import build as _build
 
 if not use_setuptools:
-    from distutils.core import setup
+    from distutils.core import Extension, setup
     from distutils.command.install import install as _install
     from distutils.command.build_ext import build_ext as _build_ext
     from distutils.command.build import build as _build
@@ -232,7 +232,8 @@ setup(name="symengine",
       url="https://github.com/symengine/symengine.py",
       python_requires='>=3.9,<4',
       zip_safe=False,
-      packages=[],
+      ext_modules=[Extension(name='symengine.lib', sources=[])],
+      packages=['symengine', 'symengine.tests'],
       cmdclass = cmdclass,
       classifiers=[
         'License :: OSI Approved :: MIT License',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if use_distutils is not None:
 
 if use_setuptools:
     try:
-        from setuptools import setup
+        from setuptools import Extension, setup
         from setuptools.command.install import install as _install
         from setuptools.command.build_ext import build_ext as _build_ext
     except ImportError:
@@ -36,7 +36,7 @@ if use_setuptools:
             from distutils.command.build import build as _build
 
 if not use_setuptools:
-    from distutils.core import setup
+    from distutils.core import Extension, setup
     from distutils.command.install import install as _install
     from distutils.command.build_ext import build_ext as _build_ext
     from distutils.command.build import build as _build
@@ -232,7 +232,8 @@ setup(name="symengine",
       url="https://github.com/symengine/symengine.py",
       python_requires='>=3.9,<4',
       zip_safe=False,
-      packages=['symengine', 'symengine.lib', 'symengine.tests'],
+      ext_modules=[Extension(name='symengine.lib', sources=[])],
+      packages=['symengine', 'symengine.tests'],
       cmdclass = cmdclass,
       classifiers=[
         'License :: OSI Approved :: MIT License',

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,8 @@ if not use_setuptools:
     from distutils.command.build import build as _build
 
 cmake_opts = [("PYTHON_BIN", sys.executable),
-              ("CMAKE_INSTALL_RPATH_USE_LINK_PATH", "yes")]
+              ("CMAKE_INSTALL_RPATH_USE_LINK_PATH", "yes"),
+              ("CMAKE_POLICY_VERSION_MINIMUM", "3.5")]
 cmake_generator = [None]
 cmake_build_type = ["Release"]
 


### PR DESCRIPTION
Those OSes have separate platlib and purelib directories. Symengine was installed partially into both from version 0.10.0 onwards. 

This change marks some of it's packages as ext_modules, which makes setuptools treat the wheel as platform specific and install if fully into platlib (lib64) instead of purelib (lib), which should solve #474.