### PR TITLE
Avoid cython warning on __nonzero__ (py2)

### DIFF
--- a/symengine/lib/symengine_wrapper.in.pyx
+++ b/symengine/lib/symengine_wrapper.in.pyx
@@ -1557,9 +1557,6 @@ cdef class BooleanFalse(BooleanAtom):
     def _sage_(self):
         return False
 
-    def __nonzero__(self):
-        return False
-
     def __bool__(self):
         return False
 


### PR DESCRIPTION
Since we no longer support python 2, we may drop this.