### PR TITLE
Support set_basic and multiset_basic with _GLIBCXX_DEBUG

### DIFF
--- a/symengine/lib/symengine.pxd
+++ b/symengine/lib/symengine.pxd
@@ -108,8 +108,27 @@ cdef extern from "<symengine/basic.h>" namespace "SymEngine":
     ctypedef map[RCP[Integer], unsigned] map_integer_uint "SymEngine::map_integer_uint"
     cdef struct RCPIntegerKeyLess
     cdef struct RCPBasicKeyLess
-    ctypedef set[rcp_const_basic] set_basic "SymEngine::set_basic"
-    ctypedef multiset[rcp_const_basic] multiset_basic "SymEngine::multiset_basic"
+    cdef cppclass set_basic "SymEngine::set_basic":
+        cppclass iterator:
+            rcp_const_basic& operator*()
+            iterator operator++() nogil
+            iterator operator--() nogil
+            bint operator==(iterator) nogil
+            bint operator!=(iterator) nogil
+        iterator begin() nogil
+        iterator end() nogil
+        iterator insert(rcp_const_basic&) nogil
+
+    cdef cppclass multiset_basic "SymEngine::multiset_basic":
+        cppclass iterator:
+            rcp_const_basic& operator*()
+            iterator operator++() nogil
+            iterator operator--() nogil
+            bint operator==(iterator) nogil
+            bint operator!=(iterator) nogil
+        iterator begin() nogil
+        iterator end() nogil
+        iterator insert(rcp_const_basic&) nogil
 
     cdef cppclass Basic:
         string __str__() nogil except +


### PR DESCRIPTION
So Cython's [declaration](https://github.com/cython/cython/blob/765d9b62b439ceae4b132339dfec18f52d7adc07/Cython/Includes/libcpp/set.pxd#L4) of `std::set` only defines a single template argument, which breaks `g++ -D_GLIBCXX_DEBUG`.

A secondary benefit of this patch is a looser coupling with exact underlying datatype used in SymEngine (at least it looks so to me).

I've been applying this patch locally for a while. If you want, I could add modify/append a config in the CI build matrix to actually exercise g++ with debug enabled standard library.